### PR TITLE
Made trac_ik_lib optional dep of sns_ik_examples

### DIFF
--- a/sns_ik_examples/CMakeLists.txt
+++ b/sns_ik_examples/CMakeLists.txt
@@ -18,7 +18,7 @@ find_package(catkin REQUIRED
   roscpp
   cmake_modules
   sns_ik_lib
-  trac_ik_lib
+  #trac_ik_lib #Uncomment this to test against trac_ik
 )
 
 find_package(Eigen REQUIRED)

--- a/sns_ik_examples/package.xml
+++ b/sns_ik_examples/package.xml
@@ -25,7 +25,8 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>sns_ik_lib</build_depend>
-  <build_depend>trac_ik_lib</build_depend>
+  <!-- Uncomment the following to run tests against trac_ik -->
+  <!-- build_depend>trac_ik_lib</build_depend -->
   <build_depend>roscpp</build_depend>
   <build_depend>eigen</build_depend>
   <build_depend>cmake_modules</build_depend>

--- a/sns_ik_examples/src/ik_tests.cpp
+++ b/sns_ik_examples/src/ik_tests.cpp
@@ -339,14 +339,6 @@ void test(ros::NodeHandle& nh, double num_samples_pos, double num_samples_vel,
       ROS_ERROR("There was no valid KDL chain found");
       return;
     }
-    valid = tracik_solver.getKDLLimits(ll,ul);
-    if (!valid) {
-      ROS_ERROR("There were no valid KDL joint limits found");
-      return;
-    }
-    assert(chain.getNrOfJoints() == ll.data.size());
-    assert(chain.getNrOfJoints() == ul.data.size());
-    ROS_INFO ("TRAC-IK Using %d joints",chain.getNrOfJoints());
 
     ROS_INFO_STREAM("*** Testing TRAC-IK with "<<num_samples_pos<<" random samples");
     if (use_nullspace_bias_task)


### PR DESCRIPTION
This commit makes `trac_ik_lib` an optional dependency
by commenting out dependencies in `sns_ik_examples`
`package.xml` and `CMakeLists.txt`. Also, a conditional
compile was added in the form of a preprocessor
pound define for `USE_TRAC`.