### PR TITLE
Added proper install directory for sns_ik headers

### DIFF
--- a/sns_ik_lib/CMakeLists.txt
+++ b/sns_ik_lib/CMakeLists.txt
@@ -31,7 +31,7 @@ catkin_package(
 
 include_directories(include ${catkin_INCLUDE_DIRS} ${Eigen3_INCLUDE_DIRS} ${orocos_kdl_INCLUDE_DIRS})
 link_directories(${orocos_kdl_LIBRARY_DIRS})
-install(DIRECTORY include/sns_ik/ DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
+install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})
 
 add_library(sns_ik src/sns_ik.cpp
             src/sns_ik_math_utils.cpp


### PR DESCRIPTION
Fixed the `sns_ik` header location install, from `CATKIN_PACKAGE_INCLUDE_DESTINATION` to `CATKIN_GLOBAL_INCLUDE_DESTINATION` according to http://docs.ros.org/indigo/api/catkin/html/user_guide/variables.html.

Keeping `CATKIN_PACKAGE_LIB_DESTINATION` the same, as it is identical to `CATKIN_GLOBAL_LIB_DESTINATION` and the doc recommends keeping is `PACKAGE`.