### PR TITLE
Adds a check for zero-joint chains, error cleanup

### DIFF
--- a/sns_ik_examples/CMakeLists.txt
+++ b/sns_ik_examples/CMakeLists.txt
@@ -16,12 +16,9 @@ endif()
 find_package(catkin REQUIRED
   COMPONENTS
   roscpp
-  cmake_modules
   sns_ik_lib
   #trac_ik_lib #Uncomment this to test against trac_ik
 )
-
-find_package(Eigen REQUIRED)
 
 catkin_package()
 

--- a/sns_ik_examples/package.xml
+++ b/sns_ik_examples/package.xml
@@ -28,9 +28,6 @@
   <!-- Uncomment the following to run tests against trac_ik -->
   <!-- build_depend>trac_ik_lib</build_depend -->
   <build_depend>roscpp</build_depend>
-  <build_depend>eigen</build_depend>
-  <build_depend>cmake_modules</build_depend>
-
   <run_depend>roscpp</run_depend>
 
 </package>

--- a/sns_ik_examples/src/ik_tests.cpp
+++ b/sns_ik_examples/src/ik_tests.cpp
@@ -162,6 +162,11 @@ void test(ros::NodeHandle& nh, double num_samples_pos, double num_samples_vel,
   KDL::Chain chain;
   KDL::JntArray ll, ul, vl, al; //lower joint limits, upper joint limits
   bool valid = false;
+  // Test invalid IK solver
+  ROS_INFO("SNS_IK Test: Trying an invalid chain:");
+  sns_ik::SNS_IK brokenik_solver(chain_start, chain_start, urdf_param, timeout, eps, sns_ik::SNS);
+  // Test valid IK solver
+  ROS_INFO("SNS_IK Test: Trying a valid chain:");
   sns_ik::SNS_IK snsik_solver(chain_start, chain_end, urdf_param, timeout, eps, sns_ik::SNS);
   valid = snsik_solver.getKDLChain(chain);
   if (!valid) {

--- a/sns_ik_lib/include/sns_ik/sns_ik.hpp
+++ b/sns_ik_lib/include/sns_ik/sns_ik.hpp
@@ -146,7 +146,7 @@ namespace sns_ik {
     std::shared_ptr<SNSPositionIK> m_ik_pos_solver;
     std::shared_ptr<KDL::ChainJntToJacSolver> m_jacobianSolver;
 
-    void initialize();
+    bool initialize();
 
     bool nullspaceBiasTask(const KDL::JntArray& q_bias,
                            const std::vector<std::string>& biasNames,


### PR DESCRIPTION
- Adds a check for zero-joint chains
- Changes all ASSERTS to be ERRORS (won't exit program)
- Adds a test for invalid initialization / logging
- Converts cout usage to ROS_INFO
- Removed unused deps for sns_ik_examples

This PR resolves #50 
