### PR TITLE
Updates for velocity IK solver

### DIFF
--- a/sns_ik_examples/src/ik_tests.cpp
+++ b/sns_ik_examples/src/ik_tests.cpp
@@ -58,7 +58,7 @@ double getDeltaWithLimits(double value, double desired_delta,
   double lower_delta = value-input_delta;
   double upper_delta = value+input_delta;
   // Randomize between upper delta and lower delta
-  if( rand() % 2 ) {
+  if (rand() % 2) {
     return upper_delta > limit_max ? lower_delta : upper_delta;
   } else {
     return lower_delta < limit_min ? upper_delta : lower_delta;
@@ -67,10 +67,10 @@ double getDeltaWithLimits(double value, double desired_delta,
 
 bool in_vel_bounds(const KDL::JntArray& vel_values, const KDL::JntArray& vel_limits)
 {
-  for(size_t i; i < vel_limits.data.size(); i++){
-      if(vel_values(i) < -vel_limits(i)-1e-6 || vel_values(i) > vel_limits(i)+1e-6){
-          return false;
-      }
+  for (int i = 0; i < vel_limits.data.size(); i++) {
+    if (vel_values(i) < -vel_limits(i)-1e-6 || vel_values(i) > vel_limits(i)+1e-6) {
+      return false;
+    }
   }
   return true;
 }
@@ -78,10 +78,10 @@ bool in_vel_bounds(const KDL::JntArray& vel_values, const KDL::JntArray& vel_lim
 bool in_pos_bounds(const KDL::JntArray& jnt_values, const KDL::JntArray& jnt_lower,
                    const KDL::JntArray& jnt_upper)
 {
-  for(size_t i; i < jnt_values.data.size(); i++){
-      if(jnt_values(i) < jnt_lower(i)-1e-6 || jnt_values(i) > jnt_upper(i)+1e-6){
-          return false;
-      }
+  for (int i = 0; i < jnt_values.data.size(); i++){
+    if (jnt_values(i) < jnt_lower(i)-1e-6 || jnt_values(i) > jnt_upper(i)+1e-6) {
+      return false;
+    }
   }
   return true;
 }
@@ -91,9 +91,9 @@ double nullspace_l2_norm_ratio(const KDL::JntArray& jnt_result, const KDL::JntAr
 {
   double error = 0;
   double ns_error = 0;
-  for(size_t i; i < jnt_ns_bias.data.size(); i++){
-      error += std::pow(jnt_result(i) - jnt_ns_bias(i), 2);
-      ns_error += std::pow(jnt_ns_result(i) - jnt_ns_bias(i), 2);
+  for (int i = 0; i < jnt_ns_bias.data.size(); i++) {
+    error += std::pow(jnt_result(i) - jnt_ns_bias(i), 2);
+    ns_error += std::pow(jnt_ns_result(i) - jnt_ns_bias(i), 2);
   }
   return std::pow(ns_error, 0.5) / std::pow(error, 0.5);
 }
@@ -397,11 +397,6 @@ void test(ros::NodeHandle& nh, double num_samples_pos, double num_samples_vel,
   velocitySolverData sns_fastoptimal = {sns_ik::SNS_FastOptimal,"SNS Fast Optimal",0.0,0.0,0.0,0.0,0.0,0.0};
   vel_solver_data.push_back(sns_fastoptimal);
 
-  // These values are not used yet
-  double posIK_linearMaxStepSize = 0.05;
-  double posIK_angularMaxStepSize = 0.05;
-  double posIK_maxIterations = 150;
-  double posIK_dt=0.2;
   for(auto& vst: vel_solver_data){
     snsik_solver.setVelocitySolveType(vst.type);
     // Initialize Solver Variables

--- a/sns_ik_lib/include/sns_ik/sns_ik.hpp
+++ b/sns_ik_lib/include/sns_ik/sns_ik.hpp
@@ -41,14 +41,14 @@ namespace sns_ik {
   public:
     SNS_IK(const std::string& base_link, const std::string& tip_link,
            const std::string& URDF_param="/robot_description",
-           double looprate=0.005, double eps=1e-5,
+           double loopPeriod=0.01, double eps=1e-5,
            sns_ik::VelocitySolveType type=sns_ik::SNS);
 
     SNS_IK(const KDL::Chain& chain,
            const KDL::JntArray& q_min, const KDL::JntArray& q_max,
            const KDL::JntArray& v_max, const KDL::JntArray& a_max,
            const std::vector<std::string>& jointNames,
-           double looprate=0.005, double eps=1e-5,
+           double loopPeriod=0.01, double eps=1e-5,
            sns_ik::VelocitySolveType type=sns_ik::SNS);
 
     ~SNS_IK();
@@ -111,32 +111,36 @@ namespace sns_ik {
                   const KDL::Twist& bounds=KDL::Twist::Zero());
 
     int CartToJntVel(const KDL::JntArray& q_in,
-                    const KDL::Twist& v_in,
-                    KDL::JntArray& qdot_out)
+                     const KDL::Twist& v_in,
+                     KDL::JntArray& qdot_out)
     { return CartToJntVel(q_in, v_in, KDL::JntArray(0), std::vector<std::string>(), qdot_out); }
 
     // Assumes the NS bias is for all the joints in the correct order
     int CartToJntVel(const KDL::JntArray& q_in,
-                    const KDL::Twist& v_in,
-                    const KDL::JntArray& q_bias,
-                    KDL::JntArray& qdot_out)
+                     const KDL::Twist& v_in,
+                     const KDL::JntArray& q_bias,
+                     KDL::JntArray& qdot_out)
     { return CartToJntVel(q_in, v_in, q_bias, m_jointNames, qdot_out); }
 
     int CartToJntVel(const KDL::JntArray& q_in,
-                    const KDL::Twist& v_in,
-                    const KDL::JntArray& q_bias,
-                    const std::vector<std::string>& biasNames,
-                    KDL::JntArray& qdot_out);
+                     const KDL::Twist& v_in,
+                     const KDL::JntArray& q_bias,
+                     const std::vector<std::string>& biasNames,
+                     KDL::JntArray& qdot_out);
 
     // Nullspace gain should be specified between 0 and 1.0
     double getNullspaceGain() { return m_nullspaceGain; }
     void setNullspaceGain(double gain)
     { m_nullspaceGain = std::max(std::min(gain, 1.0), 0.0); }
 
+    // Set time step in seconds
+    void setLoopPeriod(double loopPeriod);
+    double getLoopPeriod() { return m_loopPeriod; }
+
   private:
     bool m_initialized;
     double m_eps;
-    double m_looprate;
+    double m_loopPeriod;
     double m_nullspaceGain;
     VelocitySolveType m_solvetype;
     KDL::Chain m_chain;

--- a/sns_ik_lib/include/sns_ik/sns_ik.hpp
+++ b/sns_ik_lib/include/sns_ik/sns_ik.hpp
@@ -113,19 +113,28 @@ namespace sns_ik {
     int CartToJntVel(const KDL::JntArray& q_in,
                      const KDL::Twist& v_in,
                      KDL::JntArray& qdot_out)
-    { return CartToJntVel(q_in, v_in, KDL::JntArray(0), std::vector<std::string>(), qdot_out); }
+    { return CartToJntVel(q_in, v_in, KDL::JntArray(0), std::vector<std::string>(),
+                          KDL::JntArray(0), qdot_out); }
 
     // Assumes the NS bias is for all the joints in the correct order
     int CartToJntVel(const KDL::JntArray& q_in,
                      const KDL::Twist& v_in,
                      const KDL::JntArray& q_bias,
                      KDL::JntArray& qdot_out)
-    { return CartToJntVel(q_in, v_in, q_bias, m_jointNames, qdot_out); }
+    { return CartToJntVel(q_in, v_in, q_bias, m_jointNames, KDL::JntArray(0), qdot_out); }
+
+    int CartToJntVel(const KDL::JntArray& q_in,
+                         const KDL::Twist& v_in,
+                         const KDL::JntArray& q_bias,
+                         const KDL::JntArray& q_vel_bias,
+                         KDL::JntArray& qdot_out)
+    { return CartToJntVel(q_in, v_in, q_bias, m_jointNames, q_vel_bias, qdot_out); }
 
     int CartToJntVel(const KDL::JntArray& q_in,
                      const KDL::Twist& v_in,
                      const KDL::JntArray& q_bias,
                      const std::vector<std::string>& biasNames,
+                     const KDL::JntArray& q_vel_bias,
                      KDL::JntArray& qdot_out);
 
     // Nullspace gain should be specified between 0 and 1.0
@@ -136,6 +145,8 @@ namespace sns_ik {
     // Set time step in seconds
     void setLoopPeriod(double loopPeriod);
     double getLoopPeriod() { return m_loopPeriod; }
+
+    bool getTaskScaleFactors(std::vector<Scalar>& scaleFactors);
 
   private:
     bool m_initialized;

--- a/sns_ik_lib/include/sns_ik/sns_ik.hpp
+++ b/sns_ik_lib/include/sns_ik/sns_ik.hpp
@@ -83,6 +83,10 @@ namespace sns_ik {
       return m_initialized;
     }
 
+    bool setMaxJointVelocity(const KDL::JntArray& vel);
+
+    bool setMaxJointAcceleration(const KDL::JntArray& accel);
+
     int CartToJnt(const KDL::JntArray &q_init,
                   const KDL::Frame &p_in,
                   KDL::JntArray &q_out,

--- a/sns_ik_lib/include/sns_ik/sns_velocity_ik.hpp
+++ b/sns_ik_lib/include/sns_ik/sns_velocity_ik.hpp
@@ -64,14 +64,14 @@ class SNSVelocityIK {
 
     // SNS Velocity IK
     virtual Scalar getJointVelocity(VectorD *jointVelocity, const std::vector<Task> &sot,
-                            const VectorD &jointConfiguration);
+                                    const VectorD &jointConfiguration);
 
     // Standard straight inverse jacobian
     Scalar getJointVelocity_STD(VectorD *jointVelocity, const std::vector<Task> &sot);
 
     // The standard velocity IK solver doesn't need the joint configuration, but it's here for consistancy
     Scalar getJointVelocity_STD(VectorD *jointVelocity, const std::vector<Task> &sot,
-                            const VectorD &jointConfiguration)
+                                const VectorD &jointConfiguration)
         { return getJointVelocity_STD(jointVelocity, sot); }
 
     std::vector<Scalar> getTasksScaleFactor()

--- a/sns_ik_lib/include/sns_ik/sns_velocity_ik.hpp
+++ b/sns_ik_lib/include/sns_ik/sns_velocity_ik.hpp
@@ -33,8 +33,6 @@ namespace sns_ik {
 
 /*! \struct Task
  *  A desired robot task
- *  \todo for now we are not able to work in acceleration becouse we need the derivative of the Jacobian, but we should consider also the
- *  pre-Jacobian, post-Jacobian and augmented_Jacobian in the derivate... how can we do that?
  */
 
 struct Task {
@@ -54,8 +52,10 @@ class SNSVelocityIK {
     SNSVelocityIK(int dof, Scalar loop_period);
     virtual ~SNSVelocityIK() {};
 
-    bool setJointsCapabilities(VectorD limit_low, VectorD limit_high,
-                               VectorD maxVelocity, VectorD maxAcceleration);
+    bool setJointsCapabilities(const VectorD limit_low, const VectorD limit_high,
+                               const VectorD maxVelocity, const VectorD maxAcceleration);
+    bool setMaxJointVelocity(const VectorD maxVelocity);
+    bool setMaxJointAcceleration(const VectorD maxAcceleration);
     virtual void setNumberOfTasks(int ntasks, int dof = -1);
     virtual void setNumberOfDOF(int dof);
 

--- a/sns_ik_lib/src/fosns_velocity_ik.cpp
+++ b/sns_ik_lib/src/fosns_velocity_ik.cpp
@@ -93,11 +93,14 @@ Scalar FOSNSVelocityIK::getJointVelocity(VectorD *jointVelocity,
     }
   }
 
-  double nSatTot = 0.0;
-  for (int i = 0; i < n_tasks; i++)
-    nSatTot += nSat[i];
-  return nSatTot;
+//  double nSatTot = 0.0;
+//  for (int i = 0; i < n_tasks; i++)
+//    nSatTot += nSat[i];
+//  return nSatTot;
+  return 1.0;
 }
+
+//#define LOG_ACTIVE
 
 Scalar FOSNSVelocityIK::SNSsingle(int priority,
                                   const VectorD &higherPriorityJointVelocity,
@@ -342,10 +345,10 @@ Scalar FOSNSVelocityIK::SNSsingle(int priority,
           int id=*it;
           if (dqn(id)>=0) scaledMU(id)=-scaledMU(id);
         }
-        log<<"/nstart scale "<< scalingFactor<<std::endl;
-        //log<<"/nstart scaled Mu "<< scaledMU.transpose()<<std::endl;
-        log<<"/nstart scaled dq "<< (higherPriorityJointVelocity+scalingFactor*dq1+dq2+dqw).transpose()<<std::endl;
-        log<<"/nstart S "<<S[priority].transpose();
+        log<<"\nstart scale "<< scalingFactor<<std::endl;
+        //log<<"\nstart scaled Mu "<< scaledMU.transpose()<<std::endl;
+        log<<"\nstart scaled dq "<< (higherPriorityJointVelocity+scalingFactor*dq1+dq2+dqw).transpose()<<std::endl;
+        log<<"\nstart S "<<S[priority].transpose();
         //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%5
 #endif
         //find the minimum negative mu
@@ -361,7 +364,7 @@ Scalar FOSNSVelocityIK::SNSsingle(int priority,
           }
         }
 #ifdef LOG_ACTIVE
-        log<<"/nstart Mu "<< lagrangeMu.transpose()<<std::endl;
+        log<<"\nstart Mu "<< lagrangeMu.transpose()<<std::endl;
 #endif
       }
     }

--- a/sns_ik_lib/src/fosns_velocity_ik.cpp
+++ b/sns_ik_lib/src/fosns_velocity_ik.cpp
@@ -30,7 +30,7 @@ using namespace sns_ik;
 
 FOSNSVelocityIK::FOSNSVelocityIK(int dof, Scalar loop_period) :
     FSNSVelocityIK(dof, loop_period),
-    scaleMargin(0.9)
+    scaleMargin(0.98)
 {
 }
 

--- a/sns_ik_lib/src/fosns_velocity_ik.cpp
+++ b/sns_ik_lib/src/fosns_velocity_ik.cpp
@@ -146,7 +146,7 @@ Scalar FOSNSVelocityIK::SNSsingle(int priority,
   int id_min_mu = n_dof + 1;  //just to be not possible
   VectorD scaledMU;
 
-  bool computedScalingFactor;
+  bool computedScalingFactor = false;
 
 #ifdef LOG_ACTIVE
   int n_in=0,n_out=0;
@@ -176,7 +176,7 @@ Scalar FOSNSVelocityIK::SNSsingle(int priority,
 
   if (scalingFactor >= 1.0) {
     // then is clearly the optimum since all joints velocity are computed with the pseudoinverse
-    (*jointVelocity) = dotQ;
+    *jointVelocity = dotQ;
     //dotQopt[priority]=dotQ;
     nSat[priority] = 0;
     satList[priority].clear();
@@ -210,7 +210,7 @@ Scalar FOSNSVelocityIK::SNSsingle(int priority,
     // the task is singular so return a scaled damped solution (no SNS possible)
 
     if (scalingFactor > 0.0) {
-      (*jointVelocity) = higherPriorityJointVelocity + scalingFactor * dq1 + dq2;
+      *jointVelocity = higherPriorityJointVelocity + scalingFactor * dq1 + dq2;
       //dotQopt[priority]=(*jointVelocity);
       *nullSpaceProjector = tildeZ * tildeZ.transpose();
     } else {

--- a/sns_ik_lib/src/fsns_velocity_ik.cpp
+++ b/sns_ik_lib/src/fsns_velocity_ik.cpp
@@ -119,13 +119,13 @@ Scalar FSNSVelocityIK::SNSsingle(int priority,
     (*jointVelocity) = dotQ;
     nSat[priority] = 0;
     dotQopt[priority] = dotQ;
-    return scalingFactor;
+    return 1.0;
   }
 
   if (singularTask) {
     // the task is singular so return a scaled damped solution (no SNS possible)
-    //ROS_ERROR("singular");
-    if (scalingFactor >= 0.0) {
+    //ROS_ERROR("Singular. Scaling Factor = %.6f", scalingFactor);
+    if (scalingFactor > 0.0) {
       nSat[priority] = 0;
       (*jointVelocity) = higherPriorityJointVelocity + scalingFactor * dq1 + dq2;
       dotQopt[priority] = (*jointVelocity);
@@ -180,7 +180,7 @@ Scalar FSNSVelocityIK::SNSsingle(int priority,
     //saturate the most critical joint
     zin = tildeZ.row(mostCriticalJoint);
 
-    if ((zin.norm() < 1e-8) || (scalingFactor < 1e-12)) {
+    if ((zin.norm() < 1e-8) || (scalingFactor < 1e-6)) {
       if (best_Scale >= 0) {
         //take the best solution
         *jointVelocity = higherPriorityJointVelocity + best_Scale * best_dq1 + best_dq2 + best_dqw;
@@ -227,7 +227,7 @@ Scalar FSNSVelocityIK::SNSsingle(int priority,
       *jointVelocity = dotQ;
       dotQopt[priority] = (*jointVelocity);
       *nullSpaceProjector = tildeZ * tildeZ.transpose();  //if start net task from previous saturations
-      return scalingFactor;
+      return 1.0;
     } else {
       if ((scalingFactor > best_Scale)) {
         //save best solution so far

--- a/sns_ik_lib/src/fsns_velocity_ik.cpp
+++ b/sns_ik_lib/src/fsns_velocity_ik.cpp
@@ -68,12 +68,12 @@ Scalar FSNSVelocityIK::getJointVelocity(VectorD *jointVelocity,
 }
 
 Scalar FSNSVelocityIK::SNSsingle(int priority,
-                                const VectorD &higherPriorityJointVelocity,
-                                const MatrixD &higherPriorityNull,
-                                const MatrixD &jacobian,
-                                const VectorD &task,
-                                VectorD *jointVelocity,
-                                MatrixD *nullSpaceProjector)
+                                 const VectorD &higherPriorityJointVelocity,
+                                 const MatrixD &higherPriorityNull,
+                                 const MatrixD &jacobian,
+                                 const VectorD &task,
+                                 VectorD *jointVelocity,
+                                 MatrixD *nullSpaceProjector)
 {
   //FIXME: THERE IS A PROBLEM if we use 3 tasks... to be checked
 

--- a/sns_ik_lib/src/sns_ik.cpp
+++ b/sns_ik_lib/src/sns_ik.cpp
@@ -319,4 +319,14 @@ bool SNS_IK::nullspaceBiasTask(const KDL::JntArray& q_bias,
 
 SNS_IK::~SNS_IK(){}
 
+bool SNS_IK::setMaxJointVelocity(const KDL::JntArray& vel) {
+  m_velocity = vel;
+  return m_ik_vel_solver->setMaxJointVelocity(vel.data);
+}
+
+bool SNS_IK::setMaxJointAcceleration(const KDL::JntArray& accel) {
+  m_acceleration = accel;
+  return m_ik_vel_solver->setMaxJointAcceleration(accel.data);
+}
+
 } // sns_ik namespace

--- a/sns_ik_lib/src/sns_ik.cpp
+++ b/sns_ik_lib/src/sns_ik.cpp
@@ -309,8 +309,6 @@ int SNS_IK::CartToJntVel(const KDL::JntArray& q_in, const KDL::Twist& v_in,
       task2.desired(ii) = q_vel_bias(ii);
     }
     sot.push_back(task2);
-    //ROS_ERROR_THROTTLE(0.05, "Velocity bias: (%.4f, %.4f, %.4f, %.4f, %.4f, %.4f, %.4f)",
-    //    task2.desired(0),task2.desired(1),task2.desired(2),task2.desired(3),task2.desired(4),task2.desired(5),task2.desired(6));
   }
 
   return m_ik_vel_solver->getJointVelocity(&qdot_out.data, sot, q_in.data);

--- a/sns_ik_lib/src/sns_ik.cpp
+++ b/sns_ik_lib/src/sns_ik.cpp
@@ -27,11 +27,11 @@
 namespace sns_ik {
 
   SNS_IK::SNS_IK(const std::string& base_link, const std::string& tip_link,
-                 const std::string& URDF_param, double looprate, double eps,
+                 const std::string& URDF_param, double loopPeriod, double eps,
                  sns_ik::VelocitySolveType type) :
     m_initialized(false),
     m_eps(eps),
-    m_looprate(looprate),
+    m_loopPeriod(loopPeriod),
     m_nullspaceGain(1.0),
     m_solvetype(type)
   {
@@ -130,10 +130,10 @@ namespace sns_ik {
   SNS_IK::SNS_IK(const KDL::Chain& chain, const KDL::JntArray& q_min,
                  const KDL::JntArray& q_max, const KDL::JntArray& v_max,
                  const KDL::JntArray& a_max, const std::vector<std::string>& jointNames,
-                 double looprate, double eps, sns_ik::VelocitySolveType type):
+                 double loopPeriod, double eps, sns_ik::VelocitySolveType type):
     m_initialized(false),
     m_eps(eps),
-    m_looprate(looprate),
+    m_loopPeriod(loopPeriod),
     m_nullspaceGain(1.0),
     m_solvetype(type),
     m_chain(chain),
@@ -186,23 +186,23 @@ bool SNS_IK::setVelocitySolveType(VelocitySolveType type) {
   if(m_solvetype != type || !m_ik_vel_solver){
     switch (type) {
       case sns_ik::SNS_OptimalScaleMargin:
-        m_ik_vel_solver = std::shared_ptr<OSNS_sm_VelocityIK>(new OSNS_sm_VelocityIK(m_chain.getNrOfJoints(), m_looprate));
+        m_ik_vel_solver = std::shared_ptr<OSNS_sm_VelocityIK>(new OSNS_sm_VelocityIK(m_chain.getNrOfJoints(), m_loopPeriod));
         ROS_INFO("SNS_IK: Set Velocity solver to SNS Optimal Scale Margin solver.");
         break;
       case sns_ik::SNS_Optimal:
-        m_ik_vel_solver = std::shared_ptr<OSNSVelocityIK>(new OSNSVelocityIK(m_chain.getNrOfJoints(), m_looprate));
+        m_ik_vel_solver = std::shared_ptr<OSNSVelocityIK>(new OSNSVelocityIK(m_chain.getNrOfJoints(), m_loopPeriod));
         ROS_INFO("SNS_IK: Set Velocity solver to SNS Optimal solver.");
         break;
       case sns_ik::SNS_Fast:
-        m_ik_vel_solver = std::shared_ptr<FSNSVelocityIK>(new FSNSVelocityIK(m_chain.getNrOfJoints(), m_looprate));
+        m_ik_vel_solver = std::shared_ptr<FSNSVelocityIK>(new FSNSVelocityIK(m_chain.getNrOfJoints(), m_loopPeriod));
         ROS_INFO("SNS_IK: Set Velocity solver to Fast SNS solver.");
         break;
       case sns_ik::SNS_FastOptimal:
-        m_ik_vel_solver = std::shared_ptr<FOSNSVelocityIK>(new FOSNSVelocityIK(m_chain.getNrOfJoints(), m_looprate));
+        m_ik_vel_solver = std::shared_ptr<FOSNSVelocityIK>(new FOSNSVelocityIK(m_chain.getNrOfJoints(), m_loopPeriod));
         ROS_INFO("SNS_IK: Set Velocity solver to Fast Optimal SNS solver.");
         break;
       case sns_ik::SNS:
-        m_ik_vel_solver = std::shared_ptr<SNSVelocityIK>(new SNSVelocityIK(m_chain.getNrOfJoints(), m_looprate));
+        m_ik_vel_solver = std::shared_ptr<SNSVelocityIK>(new SNSVelocityIK(m_chain.getNrOfJoints(), m_loopPeriod));
         ROS_INFO("SNS_IK: Set Velocity solver to Standard SNS solver.");
         break;
       default:
@@ -252,9 +252,9 @@ int SNS_IK::CartToJnt(const KDL::JntArray &q_init, const KDL::Frame &p_in,
 }
 
 int SNS_IK::CartToJntVel(const KDL::JntArray& q_in, const KDL::Twist& v_in,
-                        const KDL::JntArray& q_bias,
-                        const std::vector<std::string>& biasNames,
-                        KDL::JntArray& qdot_out)
+                         const KDL::JntArray& q_bias,
+                         const std::vector<std::string>& biasNames,
+                         KDL::JntArray& qdot_out)
 {
   if (!m_initialized) {
     ROS_ERROR("SNS_IK was not properly initialized with a valid chain or limits.");
@@ -292,7 +292,7 @@ int SNS_IK::CartToJntVel(const KDL::JntArray& q_in, const KDL::Twist& v_in,
     for (size_t ii = 0; ii < q_bias.rows(); ++ii) {
       // This calculates a "nullspace velocity".
       // There is an arbitrary scale factor which will be set by the max scale factor.
-      task2.desired(ii) = m_nullspaceGain * (q_bias(ii) - q_in(indicies[ii])) / m_looprate;
+      task2.desired(ii) = m_nullspaceGain * (q_bias(ii) - q_in(indicies[ii])) / m_loopPeriod;
       // TODO: may want to limit the NS velocity to 70-90% of max joint velocity
     }
     sot.push_back(task2);
@@ -305,7 +305,7 @@ bool SNS_IK::nullspaceBiasTask(const KDL::JntArray& q_bias,
                                MatrixD* jacobian,
                                std::vector<int>* indicies)
 {
-  ROS_ASSERT_MSG(q_bias.rows() == biasNames.size(), "SNS_IK: Number of joint bias and names differe");
+  ROS_ASSERT_MSG(q_bias.rows() == biasNames.size(), "SNS_IK: Number of joint bias and names differ");
   Task task2;
   *jacobian = MatrixD::Zero(m_jointNames.size(), q_bias.rows());
   indicies->resize(q_bias.rows(), 0);
@@ -329,6 +329,11 @@ SNS_IK::~SNS_IK(){}
 bool SNS_IK::setMaxJointVelocity(const KDL::JntArray& vel) {
   m_velocity = vel;
   return m_ik_vel_solver->setMaxJointVelocity(vel.data);
+}
+
+void SNS_IK::setLoopPeriod(double loopPeriod) {
+  m_loopPeriod = loopPeriod;
+  m_ik_vel_solver->setLoopPeriod(loopPeriod);
 }
 
 bool SNS_IK::setMaxJointAcceleration(const KDL::JntArray& accel) {

--- a/sns_ik_lib/src/sns_position_ik.cpp
+++ b/sns_ik_lib/src/sns_position_ik.cpp
@@ -44,12 +44,12 @@ SNSPositionIK::~SNSPositionIK()
 }
 
 bool SNSPositionIK::calcPoseError(const KDL::JntArray& q,
-                                         const KDL::Frame& goal,
-                                         KDL::Frame* pose,
-                                         double* errL,
-                                         double* errR,
-                                         KDL::Vector* trans,
-                                         KDL::Vector* rotAxis)
+                                  const KDL::Frame& goal,
+                                  KDL::Frame* pose,
+                                  double* errL,
+                                  double* errR,
+                                  KDL::Vector* trans,
+                                  KDL::Vector* rotAxis)
 {
   if (m_positionFK.JntToCart(q, *pose) < 0)
   {

--- a/sns_ik_lib/src/sns_velocity_ik.cpp
+++ b/sns_ik_lib/src/sns_velocity_ik.cpp
@@ -37,8 +37,8 @@ SNSVelocityIK::SNSVelocityIK(int dof, Scalar loop_period) :
   setLoopPeriod(loop_period);
 }
 
-bool SNSVelocityIK::setJointsCapabilities(VectorD limit_low, VectorD limit_high,
-                                          VectorD maxVelocity, VectorD maxAcceleration)
+bool SNSVelocityIK::setJointsCapabilities(const VectorD limit_low, const VectorD limit_high,
+                                          const VectorD maxVelocity, const VectorD maxAcceleration)
 {
   if (limit_low.rows() != n_dof || limit_high.rows() != n_dof
       || maxVelocity.rows() != n_dof || maxAcceleration.rows() != n_dof) {
@@ -52,6 +52,28 @@ bool SNSVelocityIK::setJointsCapabilities(VectorD limit_low, VectorD limit_high,
 
   dotQmin = -maxJointVelocity.array();
   dotQmax = maxJointVelocity.array();
+
+  return true;
+}
+
+bool SNSVelocityIK::setMaxJointVelocity(const VectorD maxVelocity)
+{
+  if (maxVelocity.rows() != n_dof) {
+    return false;
+  }
+
+  maxJointVelocity = maxVelocity;
+  dotQmin = -maxJointVelocity.array();
+  dotQmax = maxJointVelocity.array();
+
+  return true;
+}
+
+bool SNSVelocityIK::setMaxJointAcceleration(const VectorD maxAcceleration)
+{
+  if (maxAcceleration.rows() != n_dof) {
+    return false;
+  }
 
   return true;
 }


### PR DESCRIPTION
A number of changes for smoother velocity IK when used for Cartesian motions.
1) Setters for loop period, joint velocity limits, and joint acceleration limits
2) Turn on position limits for velocity IK
3) Included option for secondary nullspace velocity tasks (ended up not using)
4) Increased the scale margin for FOSNS
5) General code cleanup


Test results:
************************************
Position IK Summary:
SNS: 91.00% success rate with (time: 1.22 ± 1.22 ms)
SNS Optimal Scale Margin: 90.50% success rate with (time: 2.00 ± 2.03 ms)
SNS Optimal: 89.00% success rate with (time: 1.66 ± 1.88 ms)
SNS Fast: 91.00% success rate with (time: 0.54 ± 0.53 ms)
SNS Fast Optimal: 91.00% success rate with (time: 0.86 ± 0.84 ms)
KDL: 30.50% success rate with (time: 1.31 ± 0.60 ms)
TRAC: 100.00% success rate with (time: 0.71 ± 0.67 ms)

************************************
Velocity IK Summary:
SNS: 84.80% w/o and 100.00% w/ scaling success rates with an average time of 0.043 ms
SNS Optimal Scale Margin: 34.90% w/o and 100.00% w/ scaling success rates with an average time of 0.073 ms
SNS Optimal: 82.90% w/o and 97.40% w/ scaling success rates with an average time of 0.048 ms
SNS Fast: 84.80% w/o and 100.00% w/ scaling success rates with an average time of 0.031 ms
SNS Fast Optimal: 71.50% w/o and 100.00% w/ scaling success rates with an average time of 0.043 ms
KDL Velocity: 73.10% w/o and 73.10% w/ scaling success rates with an average time of 0.011 ms
