### PR TITLE
Eigen cleanup

### DIFF
--- a/sns_ik_examples/CMakeLists.txt
+++ b/sns_ik_examples/CMakeLists.txt
@@ -16,18 +16,21 @@ endif()
 find_package(catkin REQUIRED
   COMPONENTS
   roscpp
-  cmake_modules
   sns_ik_lib
   #trac_ik_lib #Uncomment this to test against trac_ik
 )
 
-find_package(Eigen REQUIRED)
+find_package(Eigen3 REQUIRED)
+set(Eigen3_INCLUDE_DIRS ${EIGEN3_INCLUDE_DIRS})
 
-catkin_package()
+catkin_package(
+  DEPENDS Eigen3
+  CATKIN_DEPENDS roscpp
+)
 
 include_directories(
   ${catkin_INCLUDE_DIRS}
-  ${Eigen_INCLUDE_DIRS}
+  ${Eigen3_INCLUDE_DIRS}
 )
 
 add_executable(all_ik_tests src/ik_tests.cpp)

--- a/sns_ik_examples/package.xml
+++ b/sns_ik_examples/package.xml
@@ -29,7 +29,6 @@
   <!-- build_depend>trac_ik_lib</build_depend -->
   <build_depend>roscpp</build_depend>
   <build_depend>eigen</build_depend>
-  <build_depend>cmake_modules</build_depend>
 
   <run_depend>roscpp</run_depend>
 

--- a/sns_ik_lib/CMakeLists.txt
+++ b/sns_ik_lib/CMakeLists.txt
@@ -15,6 +15,7 @@ endif()
 
 find_package(orocos_kdl REQUIRED)
 find_package(Eigen3 REQUIRED)
+set(Eigen3_INCLUDE_DIRS ${EIGEN3_INCLUDE_DIRS})
 find_package(catkin REQUIRED
   COMPONENTS
   roscpp
@@ -29,7 +30,7 @@ catkin_package(
   LIBRARIES sns_ik
 )
 
-include_directories(include ${catkin_INCLUDE_DIRS} ${Eigen3_INCLUDE_DIRS} ${orocos_kdl_INCLUDE_DIRS})
+include_directories(include ${catkin_INCLUDE_DIRS} ${EIGEN3_INCLUDE_DIRS} ${orocos_kdl_INCLUDE_DIRS})
 link_directories(${orocos_kdl_LIBRARY_DIRS})
 install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})
 
@@ -41,5 +42,7 @@ add_library(sns_ik src/sns_ik.cpp
             src/osns_sm_velocity_ik.cpp
             src/fsns_velocity_ik.cpp
             src/fosns_velocity_ik.cpp)
-target_link_libraries(sns_ik ${catkin_LIBRARIES} ${Eigen3_INCLUDE_DIRS} ${orocos_kdl_LIBRARIES})
+target_link_libraries(sns_ik ${catkin_LIBRARIES} ${orocos_kdl_LIBRARIES})
+
 install(TARGETS sns_ik LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
+install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})

--- a/sns_ik_lib/src/sns_ik_math_utils.cpp
+++ b/sns_ik_lib/src/sns_ik_math_utils.cpp
@@ -223,7 +223,7 @@ bool pinv_forBarP(const MatrixD &W, const MatrixD &P, MatrixD *inv) {
   MatrixD tmp;
   bool invertible;
 
-  int sizeBarW = (W.diagonal().array() > 0.99).sum();
+  int sizeBarW = (W.diagonal().array() > 0.99).cast<int>().sum();
   MatrixD barW(sizeBarW, W.cols());
   int rowsBarW = 0;
 


### PR DESCRIPTION
Two fixes included:
- **Fixes Eigen scalar sum warning**

  Eigen doesn't like the fact that we're creating an Array
  of Bools, and then attempting to sum those booleans up.

  Instead, we need to cast the Array into an int, and then
  sum over it to store into the sum integer.

  Resolves #56 

- **CMakeLists Eigen cleanup**

  In ROS Kinetic, cmake_modules is deprecated,
  so we will use some alternative CMakeLists
  strategies to find_package the Eigen 3.x library.

  Resolves #57