### PR TITLE
Remove preprocessor switch float vs double

### DIFF
--- a/sns_ik_lib/CHANGELOG.rst
+++ b/sns_ik_lib/CHANGELOG.rst
@@ -8,7 +8,7 @@ Changelog for package sns_ik_lib
   In ROS Kinetic, cmake_modules is deprecated,
   so we will use some alternative CMakeLists
   strategies to find_package the Eigen 3.x library.
-* Fixes Eigen double sum warning
+* Fixes Eigen scalar sum warning
   Eigen doesn't like the fact that we're creating an Array
   of Bools, and then attempting to sum those booleans up.
   Instead, we need to cast the Array into an int, and then

--- a/sns_ik_lib/CHANGELOG.rst
+++ b/sns_ik_lib/CHANGELOG.rst
@@ -8,7 +8,7 @@ Changelog for package sns_ik_lib
   In ROS Kinetic, cmake_modules is deprecated,
   so we will use some alternative CMakeLists
   strategies to find_package the Eigen 3.x library.
-* Fixes Eigen scalar sum warning
+* Fixes Eigen double sum warning
   Eigen doesn't like the fact that we're creating an Array
   of Bools, and then attempting to sum those booleans up.
   Instead, we need to cast the Array into an int, and then

--- a/sns_ik_lib/include/sns_ik/fosns_velocity_ik.hpp
+++ b/sns_ik_lib/include/sns_ik/fosns_velocity_ik.hpp
@@ -36,12 +36,12 @@ namespace sns_ik {
 
 class FOSNSVelocityIK : public FSNSVelocityIK {
   public:
-    FOSNSVelocityIK(int dof, Scalar loop_period);
+    FOSNSVelocityIK(int dof, double loop_period);
     virtual ~FOSNSVelocityIK() {};
 
     // Optimal SNS Velocity IK
-    virtual Scalar getJointVelocity(VectorD *jointVelocity, const std::vector<Task> &sot,
-                  const VectorD &jointConfiguration);
+    virtual double getJointVelocity(Eigen::VectorXd *jointVelocity, const std::vector<Task> &sot,
+                  const Eigen::VectorXd &jointConfiguration);
 
     virtual void setNumberOfTasks(int ntasks, int dof);
 
@@ -55,17 +55,17 @@ class FOSNSVelocityIK : public FSNSVelocityIK {
 
     // For the FastOpt version of the SNS
     // TODO: should these be member variables?
-    MatrixD B;  //update matrix
+    Eigen::MatrixXd B;  //update matrix
     std::vector<std::forward_list<int>> satList;
-    VectorD lagrangeMu;
-    VectorD lagrangeMu1;
-    VectorD lagrangeMup2w;
+    Eigen::VectorXd lagrangeMu;
+    Eigen::VectorXd lagrangeMu1;
+    Eigen::VectorXd lagrangeMup2w;
     std::forward_list<int>::iterator it, prev_it;
 
     // Perform the SNS for a single task
-    virtual Scalar SNSsingle(int priority, const VectorD &higherPriorityJointVelocity,
-                   const MatrixD &higherPriorityNull, const MatrixD &jacobian,
-                   const VectorD &task, VectorD *jointVelocity, MatrixD *nullSpaceProjector);
+    virtual double SNSsingle(int priority, const Eigen::VectorXd &higherPriorityJointVelocity,
+                   const Eigen::MatrixXd &higherPriorityNull, const Eigen::MatrixXd &jacobian,
+                   const Eigen::VectorXd &task, Eigen::VectorXd *jointVelocity, Eigen::MatrixXd *nullSpaceProjector);
 };
 
 }  // namespace sns_ikl

--- a/sns_ik_lib/include/sns_ik/fosns_velocity_ik.hpp
+++ b/sns_ik_lib/include/sns_ik/fosns_velocity_ik.hpp
@@ -30,8 +30,6 @@
 #include "sns_ik/sns_velocity_ik.hpp"
 #include "sns_ik/fsns_velocity_ik.hpp"
 
-using namespace Eigen;
-
 namespace sns_ik {
 
 class FOSNSVelocityIK : public FSNSVelocityIK {
@@ -68,6 +66,6 @@ class FOSNSVelocityIK : public FSNSVelocityIK {
                    const Eigen::VectorXd &task, Eigen::VectorXd *jointVelocity, Eigen::MatrixXd *nullSpaceProjector);
 };
 
-}  // namespace sns_ikl
+}  // namespace sns_ik
 
 #endif

--- a/sns_ik_lib/include/sns_ik/fsns_velocity_ik.hpp
+++ b/sns_ik_lib/include/sns_ik/fsns_velocity_ik.hpp
@@ -36,22 +36,22 @@ namespace sns_ik {
 
 class FSNSVelocityIK : public SNSVelocityIK {
   public:
-    FSNSVelocityIK(int dof, Scalar loop_period);
+    FSNSVelocityIK(int dof, double loop_period);
     virtual ~FSNSVelocityIK() {};
 
     // Optimal SNS Velocity IK
-    virtual Scalar getJointVelocity(VectorD *jointVelocity, const std::vector<Task> &sot,
-                  const VectorD &jointConfiguration);
+    virtual double getJointVelocity(Eigen::VectorXd *jointVelocity, const std::vector<Task> &sot,
+                  const Eigen::VectorXd &jointConfiguration);
 
   protected:
     // Perform the SNS for a single task
-    virtual Scalar SNSsingle(int priority, const VectorD &higherPriorityJointVelocity,
-                  const MatrixD &higherPriorityNull, const MatrixD &jacobian,
-                  const VectorD &task, VectorD *jointVelocity, MatrixD *nullSpaceProjector);
+    virtual double SNSsingle(int priority, const Eigen::VectorXd &higherPriorityJointVelocity,
+                  const Eigen::MatrixXd &higherPriorityNull, const Eigen::MatrixXd &jacobian,
+                  const Eigen::VectorXd &task, Eigen::VectorXd *jointVelocity, Eigen::MatrixXd *nullSpaceProjector);
 
-    void getTaskScalingFactor(const Array<Scalar, Dynamic, 1> &a,
-                  const Array<Scalar, Dynamic, 1> &b,
-                  const VectorXi &S, Scalar *scalingFactor,
+    void getTaskScalingFactor(const Array<double, Dynamic, 1> &a,
+                  const Array<double, Dynamic, 1> &b,
+                  const VectorXi &S, double *scalingFactor,
                   int *mostCriticalJoint);
 
     // TODO: Does this need to be a member variable?

--- a/sns_ik_lib/include/sns_ik/fsns_velocity_ik.hpp
+++ b/sns_ik_lib/include/sns_ik/fsns_velocity_ik.hpp
@@ -30,8 +30,6 @@
 
 //#define LOG_ACTIVE
 
-using namespace Eigen;
-
 namespace sns_ik {
 
 class FSNSVelocityIK : public SNSVelocityIK {
@@ -49,15 +47,15 @@ class FSNSVelocityIK : public SNSVelocityIK {
                   const Eigen::MatrixXd &higherPriorityNull, const Eigen::MatrixXd &jacobian,
                   const Eigen::VectorXd &task, Eigen::VectorXd *jointVelocity, Eigen::MatrixXd *nullSpaceProjector);
 
-    void getTaskScalingFactor(const Array<double, Dynamic, 1> &a,
-                  const Array<double, Dynamic, 1> &b,
-                  const VectorXi &S, double *scalingFactor,
+    void getTaskScalingFactor(const Eigen::ArrayXd &a,
+                  const Eigen::ArrayXd &b,
+                  const Eigen::VectorXi &S, double *scalingFactor,
                   int *mostCriticalJoint);
 
     // TODO: Does this need to be a member variable?
-    std::vector<VectorXi> S;  //the i-th element is zero if the i-th joint is not saturate, otherwise contains the position in B
+    std::vector<Eigen::VectorXi> S;  //the i-th element is zero if the i-th joint is not saturate, otherwise contains the position in B
 };
 
-}  // namespace sns_ikl
+}  // namespace sns_ik
 
 #endif

--- a/sns_ik_lib/include/sns_ik/osns_sm_velocity_ik.hpp
+++ b/sns_ik_lib/include/sns_ik/osns_sm_velocity_ik.hpp
@@ -28,8 +28,6 @@
 #include "sns_ik/sns_ik_math_utils.hpp"
 #include "sns_ik/osns_velocity_ik.hpp"
 
-using namespace Eigen;
-
 namespace sns_ik {
 
 class OSNS_sm_VelocityIK : public OSNSVelocityIK {
@@ -50,6 +48,6 @@ class OSNS_sm_VelocityIK : public OSNSVelocityIK {
     double m_scaleMargin;
 };
 
-}  // namespace sns_ikl
+}  // namespace sns_ik
 
 #endif

--- a/sns_ik_lib/include/sns_ik/osns_sm_velocity_ik.hpp
+++ b/sns_ik_lib/include/sns_ik/osns_sm_velocity_ik.hpp
@@ -34,12 +34,12 @@ namespace sns_ik {
 
 class OSNS_sm_VelocityIK : public OSNSVelocityIK {
   public:
-    OSNS_sm_VelocityIK(int dof, Scalar loop_period);
+    OSNS_sm_VelocityIK(int dof, double loop_period);
     virtual ~OSNS_sm_VelocityIK() {};
 
     // Optimal SNS Velocity IK
-    virtual Scalar getJointVelocity(VectorD *jointVelocity, const std::vector<Task> &sot,
-                            const VectorD &jointConfiguration);
+    virtual double getJointVelocity(Eigen::VectorXd *jointVelocity, const std::vector<Task> &sot,
+                            const Eigen::VectorXd &jointConfiguration);
 
     void setScaleMargin(double scale)
       { m_scaleMargin = scale; }

--- a/sns_ik_lib/include/sns_ik/osns_velocity_ik.hpp
+++ b/sns_ik_lib/include/sns_ik/osns_velocity_ik.hpp
@@ -28,8 +28,6 @@
 #include "sns_ik/sns_ik_math_utils.hpp"
 #include "sns_ik/sns_velocity_ik.hpp"
 
-using namespace Eigen;
-
 namespace sns_ik {
 
 class OSNSVelocityIK : public SNSVelocityIK {
@@ -52,6 +50,6 @@ class OSNSVelocityIK : public SNSVelocityIK {
                    Eigen::VectorXd* dotQn, double eps = 1e-8);
 };
 
-}  // namespace sns_ikl
+}  // namespace sns_ik
 
 #endif

--- a/sns_ik_lib/include/sns_ik/osns_velocity_ik.hpp
+++ b/sns_ik_lib/include/sns_ik/osns_velocity_ik.hpp
@@ -34,22 +34,22 @@ namespace sns_ik {
 
 class OSNSVelocityIK : public SNSVelocityIK {
   public:
-    OSNSVelocityIK(int dof, Scalar loop_period);
+    OSNSVelocityIK(int dof, double loop_period);
     virtual ~OSNSVelocityIK() {};
 
     // Optimal SNS Velocity IK
-    virtual Scalar getJointVelocity(VectorD *jointVelocity, const std::vector<Task> &sot,
-                            const VectorD &jointConfiguration);
+    virtual double getJointVelocity(Eigen::VectorXd *jointVelocity, const std::vector<Task> &sot,
+                            const Eigen::VectorXd &jointConfiguration);
 
   protected:
     // Perform the SNS for a single task
-    virtual Scalar SNSsingle(int priority, const VectorD &higherPriorityJointVelocity,
-                     const MatrixD &higherPriorityNull, const MatrixD &jacobian,
-                     const VectorD &task, VectorD *jointVelocity, MatrixD *nullSpaceProjector);
+    virtual double SNSsingle(int priority, const Eigen::VectorXd &higherPriorityJointVelocity,
+                     const Eigen::MatrixXd &higherPriorityNull, const Eigen::MatrixXd &jacobian,
+                     const Eigen::VectorXd &task, Eigen::VectorXd *jointVelocity, Eigen::MatrixXd *nullSpaceProjector);
 
-    bool isOptimal(int priority, const VectorD& dotQ,
-                   const MatrixD& tildeP, MatrixD* W,
-                   VectorD* dotQn, double eps = 1e-8);
+    bool isOptimal(int priority, const Eigen::VectorXd& dotQ,
+                   const Eigen::MatrixXd& tildeP, Eigen::MatrixXd* W,
+                   Eigen::VectorXd* dotQn, double eps = 1e-8);
 };
 
 }  // namespace sns_ikl

--- a/sns_ik_lib/include/sns_ik/sns_ik.hpp
+++ b/sns_ik_lib/include/sns_ik/sns_ik.hpp
@@ -146,7 +146,7 @@ namespace sns_ik {
     void setLoopPeriod(double loopPeriod);
     double getLoopPeriod() { return m_loopPeriod; }
 
-    bool getTaskScaleFactors(std::vector<Scalar>& scaleFactors);
+    bool getTaskScaleFactors(std::vector<double>& scaleFactors);
 
   private:
     bool m_initialized;
@@ -169,7 +169,7 @@ namespace sns_ik {
 
     bool nullspaceBiasTask(const KDL::JntArray& q_bias,
                            const std::vector<std::string>& biasNames,
-                           MatrixD* jacobian, std::vector<int>* indicies);
+                           Eigen::MatrixXd* jacobian, std::vector<int>* indicies);
 
   };
 }  //namespace

--- a/sns_ik_lib/include/sns_ik/sns_ik_math_utils.hpp
+++ b/sns_ik_lib/include/sns_ik/sns_ik_math_utils.hpp
@@ -27,30 +27,25 @@
 
 namespace sns_ik {
 
-namespace {
-  const double EPS = 1e-6;
-  const double LAMBDA_MAX = 1e-6; //0.3
-}
-
 static const double INF = std::numeric_limits<double>::max();
 
 // compute the pseudoinverse of A: it return 0 if A is (row) rank deficient
-bool pinv(const Eigen::MatrixXd &A, Eigen::MatrixXd *invA, double eps = EPS);
+bool pinv(const Eigen::MatrixXd &A, Eigen::MatrixXd *invA, double eps = 1e-6);
 // compute the pseudoinverse of A: it return 0 if A is (row) rank deficient
 // return also the null space projector P=(P-pinv(A)A)
-bool pinv_P(const Eigen::MatrixXd &A, Eigen::MatrixXd *invA, Eigen::MatrixXd *P, double eps = EPS);
+bool pinv_P(const Eigen::MatrixXd &A, Eigen::MatrixXd *invA, Eigen::MatrixXd *P, double eps = 1e-6);
 // compute the pseudoinverse of A: it return 0 if A is (row) rank deficient
-bool pinv_damped(const Eigen::MatrixXd &A, Eigen::MatrixXd *invA, double lambda_max = LAMBDA_MAX,
-                 double eps = EPS);
+bool pinv_damped(const Eigen::MatrixXd &A, Eigen::MatrixXd *invA, double lambda_max = 1e-6,
+                 double eps = 1e-6);
 bool pinv_damped_P(const Eigen::MatrixXd &A, Eigen::MatrixXd *invA, Eigen::MatrixXd *P,
-                   double lambda_max = LAMBDA_MAX, double eps = EPS);
+                   double lambda_max = 1e-6, double eps = 1e-6);
 bool pinv_forBarP(const Eigen::MatrixXd &W, const Eigen::MatrixXd &P, Eigen::MatrixXd *inv);
 bool pinv_QR_Z(const Eigen::MatrixXd &A, const Eigen::MatrixXd &Z0, Eigen::MatrixXd *invA,
-               Eigen::MatrixXd *Z, double lambda_max = LAMBDA_MAX, double eps = EPS);
-bool pinv_QR(const Eigen::MatrixXd &A, Eigen::MatrixXd *invA, double eps = EPS);
+               Eigen::MatrixXd *Z, double lambda_max = 1e-6, double eps = 1e-6);
+bool pinv_QR(const Eigen::MatrixXd &A, Eigen::MatrixXd *invA, double eps = 1e-6);
 
 bool isIdentity(const Eigen::MatrixXd &A);
 
-}  // namespace sns_ikl
+}  // namespace sns_ik
 
 #endif

--- a/sns_ik_lib/include/sns_ik/sns_ik_math_utils.hpp
+++ b/sns_ik_lib/include/sns_ik/sns_ik_math_utils.hpp
@@ -25,66 +25,31 @@
 
 #include <Eigen/Dense>
 
-using namespace Eigen;
-
 namespace sns_ik {
 
-#define _USE_DOUBLE_
-/*! \def _USE_DOUBLE_
- * use values with double precision.
- * This is used to have the possibility to switch (at compile time) between float and double precision in order to be faster or more accurate.
- * Inside the \b IKL we will use the follow definition:
- * - \b MatrixD  a dynamic sized Matrix of real numbers
- * - \b VectorD a column vector of real numbers with dynamic length
- * - \b Scalar a real number
- */
-
-#ifdef _USE_DOUBLE_
-  /*! \typedef MatrixD
-   *  dynamic sized matrix of \em float values
-   *  (\em double if \b _USE_DOUBLE_ is defined)
-   */
-  typedef Eigen::Matrix<double, Dynamic, Dynamic> MatrixD;
-  /*! \typedef VectorD
-   *  dynamic sized column vector of \em float values
-   *  (\em double if \b _USE_DOUBLE_ is defined)
-   */
-  typedef Eigen::Matrix<double, Dynamic, 1> VectorD;
-  /*! \typedef Scalar
-   *  a \em float value
-   *  (\em double if \b _USE_DOUBLE_ is defined)
-   */
-  typedef double Scalar;
+namespace {
   const double EPS = 1e-6;
   const double LAMBDA_MAX = 1e-6; //0.3
-  const double EPSQ = 1e-10;
-#else
-  typedef Eigen::Matrix<float,Dynamic,Dynamic> MatrixD;
-  typedef Eigen::Matrix<float,Dynamic,1> VectorD;
-  typedef float Scalar;
-  const float EPS = 1e-6;
-  const float LAMBDA_MAX = 0.3;
-  const float EPSQ = 1e-15;
-#endif
+}
 
-#define INF 1e20;  // Should this be the std INF?
+static const double INF = std::numeric_limits<double>::max();
 
 // compute the pseudoinverse of A: it return 0 if A is (row) rank deficient
-bool pinv(const MatrixD &A, MatrixD *invA, Scalar eps = EPS);
+bool pinv(const Eigen::MatrixXd &A, Eigen::MatrixXd *invA, double eps = EPS);
 // compute the pseudoinverse of A: it return 0 if A is (row) rank deficient
 // return also the null space projector P=(P-pinv(A)A)
-bool pinv_P(const MatrixD &A, MatrixD *invA, MatrixD *P, Scalar eps = EPS);
+bool pinv_P(const Eigen::MatrixXd &A, Eigen::MatrixXd *invA, Eigen::MatrixXd *P, double eps = EPS);
 // compute the pseudoinverse of A: it return 0 if A is (row) rank deficient
-bool pinv_damped(const MatrixD &A, MatrixD *invA, Scalar lambda_max = LAMBDA_MAX,
-                 Scalar eps = EPS);
-bool pinv_damped_P(const MatrixD &A, MatrixD *invA, MatrixD *P,
-                   Scalar lambda_max = LAMBDA_MAX, Scalar eps = EPS);
-bool pinv_forBarP(const MatrixD &W, const MatrixD &P, MatrixD *inv);
-bool pinv_QR_Z(const MatrixD &A, const MatrixD &Z0, MatrixD *invA, MatrixD *Z,
-               Scalar lambda_max = LAMBDA_MAX, Scalar eps = EPS);
-bool pinv_QR(const MatrixD &A, MatrixD *invA, Scalar eps = EPS);
+bool pinv_damped(const Eigen::MatrixXd &A, Eigen::MatrixXd *invA, double lambda_max = LAMBDA_MAX,
+                 double eps = EPS);
+bool pinv_damped_P(const Eigen::MatrixXd &A, Eigen::MatrixXd *invA, Eigen::MatrixXd *P,
+                   double lambda_max = LAMBDA_MAX, double eps = EPS);
+bool pinv_forBarP(const Eigen::MatrixXd &W, const Eigen::MatrixXd &P, Eigen::MatrixXd *inv);
+bool pinv_QR_Z(const Eigen::MatrixXd &A, const Eigen::MatrixXd &Z0, Eigen::MatrixXd *invA,
+               Eigen::MatrixXd *Z, double lambda_max = LAMBDA_MAX, double eps = EPS);
+bool pinv_QR(const Eigen::MatrixXd &A, Eigen::MatrixXd *invA, double eps = EPS);
 
-bool isIdentity(const MatrixD &A);
+bool isIdentity(const Eigen::MatrixXd &A);
 
 }  // namespace sns_ikl
 

--- a/sns_ik_lib/include/sns_ik/sns_position_ik.hpp
+++ b/sns_ik_lib/include/sns_ik/sns_position_ik.hpp
@@ -41,13 +41,13 @@ class SNSPositionIK {
                   const KDL::Frame& goal_pose,
                   KDL::JntArray* return_joints,
                   const KDL::Twist& bounds=KDL::Twist::Zero())
-    { return CartToJnt(joint_seed, goal_pose, KDL::JntArray(0), MatrixD(0,0),
+    { return CartToJnt(joint_seed, goal_pose, KDL::JntArray(0), Eigen::MatrixXd(0,0),
                        std::vector<int>(0), 0.0, return_joints, bounds); }
 
     int CartToJnt(const KDL::JntArray& joint_seed,
                   const KDL::Frame& goal_pose,
                   const KDL::JntArray& joint_ns_bias,
-                  const MatrixD& ns_jacobian,
+                  const Eigen::MatrixXd& ns_jacobian,
                   const std::vector<int>& ns_indicies,
                   const double ns_gain,
                   KDL::JntArray* return_joints,

--- a/sns_ik_lib/include/sns_ik/sns_position_ik.hpp
+++ b/sns_ik_lib/include/sns_ik/sns_position_ik.hpp
@@ -141,6 +141,6 @@ class SNSPositionIK {
 
 };
 
-}  // namespace sns_ikl
+}  // namespace sns_ik
 
 #endif

--- a/sns_ik_lib/include/sns_ik/sns_velocity_ik.hpp
+++ b/sns_ik_lib/include/sns_ik/sns_velocity_ik.hpp
@@ -36,8 +36,8 @@ namespace sns_ik {
  */
 
 struct Task {
-    MatrixD jacobian;  //!< the task Jacobian
-    VectorD desired;   //!< desired velocity in task space
+    Eigen::MatrixXd jacobian;  //!< the task Jacobian
+    Eigen::VectorXd desired;   //!< desired velocity in task space
 };
 
 #define _ONLY_WARNING_ON_ERROR
@@ -49,13 +49,13 @@ struct Task {
 
 class SNSVelocityIK {
   public:
-    SNSVelocityIK(int dof, Scalar loop_period);
+    SNSVelocityIK(int dof, double loop_period);
     virtual ~SNSVelocityIK() {};
 
-    bool setJointsCapabilities(const VectorD limit_low, const VectorD limit_high,
-                               const VectorD maxVelocity, const VectorD maxAcceleration);
-    bool setMaxJointVelocity(const VectorD maxVelocity);
-    bool setMaxJointAcceleration(const VectorD maxAcceleration);
+    bool setJointsCapabilities(const Eigen::VectorXd limit_low, const Eigen::VectorXd limit_high,
+                               const Eigen::VectorXd maxVelocity, const Eigen::VectorXd maxAcceleration);
+    bool setMaxJointVelocity(const Eigen::VectorXd maxVelocity);
+    bool setMaxJointAcceleration(const Eigen::VectorXd maxAcceleration);
     virtual void setNumberOfTasks(int ntasks, int dof = -1);
     virtual void setNumberOfDOF(int dof);
 
@@ -63,60 +63,60 @@ class SNSVelocityIK {
     void setLoopPeriod(double period) { loop_period = period; }
 
     // SNS Velocity IK
-    virtual Scalar getJointVelocity(VectorD *jointVelocity, const std::vector<Task> &sot,
-                                    const VectorD &jointConfiguration);
+    virtual double getJointVelocity(Eigen::VectorXd *jointVelocity, const std::vector<Task> &sot,
+                                    const Eigen::VectorXd &jointConfiguration);
 
     // Standard straight inverse jacobian
-    Scalar getJointVelocity_STD(VectorD *jointVelocity, const std::vector<Task> &sot);
+    double getJointVelocity_STD(Eigen::VectorXd *jointVelocity, const std::vector<Task> &sot);
 
     // The standard velocity IK solver doesn't need the joint configuration, but it's here for consistancy
-    Scalar getJointVelocity_STD(VectorD *jointVelocity, const std::vector<Task> &sot,
-                                const VectorD &jointConfiguration)
+    double getJointVelocity_STD(Eigen::VectorXd *jointVelocity, const std::vector<Task> &sot,
+                                const Eigen::VectorXd &jointConfiguration)
         { return getJointVelocity_STD(jointVelocity, sot); }
 
-    std::vector<Scalar> getTasksScaleFactor()
+    std::vector<double> getTasksScaleFactor()
         { return scaleFactors; }
 
-    VectorD getJointLimitLow() { return jointLimit_low; }
-    VectorD getJointLimitHigh() { return jointLimit_high; }
-    VectorD getJointVelocityMax() { return maxJointVelocity; }
+    Eigen::VectorXd getJointLimitLow() { return jointLimit_low; }
+    Eigen::VectorXd getJointLimitHigh() { return jointLimit_high; }
+    Eigen::VectorXd getJointVelocityMax() { return maxJointVelocity; }
 
     void usePositionLimits(bool use) { m_usePositionLimits = use; }
 
   protected:
 
     // Shape the joint velocity bound dotQmin and dotQmax
-    void shapeJointVelocityBound(const VectorD &actualJointConfiguration, double margin = SHAPE_MARGIN);
+    void shapeJointVelocityBound(const Eigen::VectorXd &actualJointConfiguration, double margin = SHAPE_MARGIN);
 
     // Perform the SNS for a single task
-    virtual Scalar SNSsingle(int priority, const VectorD &higherPriorityJointVelocity,
-                     const MatrixD &higherPriorityNull, const MatrixD &jacobian,
-                     const VectorD &task, VectorD *jointVelocity, MatrixD *nullSpaceProjector);
+    virtual double SNSsingle(int priority, const Eigen::VectorXd &higherPriorityJointVelocity,
+                     const Eigen::MatrixXd &higherPriorityNull, const Eigen::MatrixXd &jacobian,
+                     const Eigen::VectorXd &task, Eigen::VectorXd *jointVelocity, Eigen::MatrixXd *nullSpaceProjector);
 
-    void getTaskScalingFactor(const Array<Scalar, Dynamic, 1> &a,
-                              const Array<Scalar, Dynamic, 1> &b,
-                              const MatrixD &W, Scalar *scalingFactor,
+    void getTaskScalingFactor(const Array<double, Dynamic, 1> &a,
+                              const Array<double, Dynamic, 1> &b,
+                              const Eigen::MatrixXd &W, double *scalingFactor,
                               int *mostCriticalJoint);
 
     int n_dof;  //manipulator degree of freedom
     int n_tasks;  //number of tasks
-    Scalar loop_period;  //needed to compute the bounds
+    double loop_period;  //needed to compute the bounds
 
-    VectorD jointLimit_low;  // low joint limits
-    VectorD jointLimit_high;  // high joint limit
-    VectorD maxJointVelocity;  // maximum joint velocity
-    VectorD maxJointAcceleration;  // maximum joint acceleration
+    Eigen::VectorXd jointLimit_low;  // low joint limits
+    Eigen::VectorXd jointLimit_high;  // high joint limit
+    Eigen::VectorXd maxJointVelocity;  // maximum joint velocity
+    Eigen::VectorXd maxJointAcceleration;  // maximum joint acceleration
     bool m_usePositionLimits;
 
-    Array<Scalar, Dynamic, 1> dotQmin;  // lower joint velocity bound
-    Array<Scalar, Dynamic, 1> dotQmax;  // higher joint velocity bound
+    Array<double, Dynamic, 1> dotQmin;  // lower joint velocity bound
+    Array<double, Dynamic, 1> dotQmax;  // higher joint velocity bound
 
     // TODO: are these needed here???
-    VectorD dotQ;  // next solution (bar{\dotqv} in the paper)
-    std::vector<MatrixD> W;  //selection matrices  [here to permit a warm start]
-    std::vector<VectorD> dotQopt;  // next solution (bar{\dotqv} in the paper)
-    MatrixD I;  // identity matrix
-    std::vector<Scalar> scaleFactors;
+    Eigen::VectorXd dotQ;  // next solution (bar{\dotqv} in the paper)
+    std::vector<Eigen::MatrixXd> W;  //selection matrices  [here to permit a warm start]
+    std::vector<Eigen::VectorXd> dotQopt;  // next solution (bar{\dotqv} in the paper)
+    Eigen::MatrixXd I;  // identity matrix
+    std::vector<double> scaleFactors;
 
     std::vector<int> nSat;  //number of saturated joint
 };

--- a/sns_ik_lib/include/sns_ik/sns_velocity_ik.hpp
+++ b/sns_ik_lib/include/sns_ik/sns_velocity_ik.hpp
@@ -27,8 +27,6 @@
 
 #include "sns_ik/sns_ik_math_utils.hpp"
 
-using namespace Eigen;
-
 namespace sns_ik {
 
 /*! \struct Task
@@ -93,8 +91,8 @@ class SNSVelocityIK {
                      const Eigen::MatrixXd &higherPriorityNull, const Eigen::MatrixXd &jacobian,
                      const Eigen::VectorXd &task, Eigen::VectorXd *jointVelocity, Eigen::MatrixXd *nullSpaceProjector);
 
-    void getTaskScalingFactor(const Array<double, Dynamic, 1> &a,
-                              const Array<double, Dynamic, 1> &b,
+    void getTaskScalingFactor(const Eigen::ArrayXd &a,
+                              const Eigen::ArrayXd &b,
                               const Eigen::MatrixXd &W, double *scalingFactor,
                               int *mostCriticalJoint);
 
@@ -108,8 +106,8 @@ class SNSVelocityIK {
     Eigen::VectorXd maxJointAcceleration;  // maximum joint acceleration
     bool m_usePositionLimits;
 
-    Array<double, Dynamic, 1> dotQmin;  // lower joint velocity bound
-    Array<double, Dynamic, 1> dotQmax;  // higher joint velocity bound
+    Eigen::ArrayXd dotQmin;  // lower joint velocity bound
+    Eigen::ArrayXd dotQmax;  // higher joint velocity bound
 
     // TODO: are these needed here???
     Eigen::VectorXd dotQ;  // next solution (bar{\dotqv} in the paper)
@@ -121,6 +119,6 @@ class SNSVelocityIK {
     std::vector<int> nSat;  //number of saturated joint
 };
 
-}  // namespace sns_ikl
+}  // namespace sns_ik
 
 #endif

--- a/sns_ik_lib/src/fosns_velocity_ik.cpp
+++ b/sns_ik_lib/src/fosns_velocity_ik.cpp
@@ -25,8 +25,7 @@
 #include <ros/ros.h>
 #include <iostream>
 
-using namespace Eigen;
-using namespace sns_ik;
+namespace sns_ik {
 
 FOSNSVelocityIK::FOSNSVelocityIK(int dof, double loop_period) :
     FSNSVelocityIK(dof, loop_period),
@@ -41,7 +40,7 @@ void FOSNSVelocityIK::setNumberOfTasks(int ntasks, int dof)
   //for the Fast version
   Eigen::MatrixXd Z = Eigen::MatrixXd::Zero(n_dof, n_dof);
   Eigen::VectorXd zv = Eigen::VectorXd::Zero(n_dof);
-  VectorXi zvi = VectorXi::Zero(n_dof);
+  Eigen::VectorXi zvi = Eigen::VectorXi::Zero(n_dof);
   B = Z;
 
   S.resize(n_tasks, zvi);
@@ -59,7 +58,7 @@ double FOSNSVelocityIK::getJointVelocity(Eigen::VectorXd *jointVelocity,
 {
   // This will only reset member variables if different from previous values
   setNumberOfTasks(sot.size(), sot[0].jacobian.cols());
-  S.resize(n_tasks, VectorXi::Zero(n_dof));
+  S.resize(n_tasks, Eigen::VectorXi::Zero(n_dof));
 
   // TODO: check that setJointsCapabilities has been already called
 
@@ -112,7 +111,7 @@ double FOSNSVelocityIK::SNSsingle(int priority,
 {
   //INITIALIZATION
   Eigen::MatrixXd JPinverse;  //(J_k P_{k-1})^#
-  Array<double, Dynamic, 1> a, b;  // used to compute the task scaling factor
+  Eigen::ArrayXd a, b;  // used to compute the task scaling factor
   bool limit_excedeed;
   double scalingFactor = 1.0;
   int mostCriticalJoint;
@@ -164,7 +163,7 @@ double FOSNSVelocityIK::SNSsingle(int priority,
   dotQ = higherPriorityJointVelocity + dq1 + dq2;
   a = dq1.array();
   b = dotQ.array() - a;
-  getTaskScalingFactor(a, b, VectorXi::Zero(n_dof), &scalingFactor, &mostCriticalJoint);
+  getTaskScalingFactor(a, b, Eigen::VectorXi::Zero(n_dof), &scalingFactor, &mostCriticalJoint);
 
 #ifdef LOG_ACTIVE
   log<<"task "<<priority<<std::endl;
@@ -180,7 +179,7 @@ double FOSNSVelocityIK::SNSsingle(int priority,
     //dotQopt[priority]=dotQ;
     nSat[priority] = 0;
     satList[priority].clear();
-    S[priority] = VectorXi::Zero(n_dof);
+    S[priority] = Eigen::VectorXi::Zero(n_dof);
 #ifdef LOG_ACTIVE
     log<<"task accomplished without saturations"<<std::endl;
     log<<"scale "<<scalingFactor<<std::endl;
@@ -230,7 +229,7 @@ double FOSNSVelocityIK::SNSsingle(int priority,
 #endif
     nSat[priority] = 0;
     satList[priority].clear();
-    S[priority] = VectorXi::Zero(n_dof);
+    S[priority] = Eigen::VectorXi::Zero(n_dof);
     return scalingFactor;
   }
 
@@ -310,7 +309,7 @@ double FOSNSVelocityIK::SNSsingle(int priority,
 #endif
         satList[priority].clear();
         nSat[priority] = 0;
-        S[priority] = VectorXi::Zero(n_dof);
+        S[priority] = Eigen::VectorXi::Zero(n_dof);
 
       } else {
 
@@ -374,7 +373,7 @@ double FOSNSVelocityIK::SNSsingle(int priority,
 //######################### else
   satList[priority].clear();
   nSat[priority]=0;
-  S[priority]=VectorXi::Zero(n_dof);
+  S[priority]=Eigen::VectorXi::Zero(n_dof);
 
 //  lagrangeMu1=Eigen::VectorXd::Zero(n_dof);
 //  lagrangeMup2w=Eigen::VectorXd::Zero(n_dof);
@@ -406,7 +405,7 @@ double FOSNSVelocityIK::SNSsingle(int priority,
       //nSat[priority]=0;
       satList[priority].clear();
       nSat[priority] = 0;
-      S[priority] = VectorXi::Zero(n_dof);
+      S[priority] = Eigen::VectorXi::Zero(n_dof);
       *jointVelocity = higherPriorityJointVelocity;
       //dotQopt[priority]=(*jointVelocity);
       *nullSpaceProjector = higherPriorityNull;
@@ -672,7 +671,7 @@ double FOSNSVelocityIK::SNSsingle(int priority,
           //no saturation was needed to obtain the best scale
           satList[priority].clear();
           nSat[priority] = 0;
-          S[priority] = VectorXi::Zero(n_dof);
+          S[priority] = Eigen::VectorXi::Zero(n_dof);
 
         }
         //if (priority==1) *jointVelocity=(*higherPriorityJointVelocity);
@@ -728,3 +727,5 @@ double FOSNSVelocityIK::SNSsingle(int priority,
   //dotQopt[priority]=(*jointVelocity);
   return scalingFactor;
 }
+
+}  // namespace sns_ik

--- a/sns_ik_lib/src/fsns_velocity_ik.cpp
+++ b/sns_ik_lib/src/fsns_velocity_ik.cpp
@@ -27,15 +27,15 @@
 using namespace Eigen;
 using namespace sns_ik;
 
-FSNSVelocityIK::FSNSVelocityIK(int dof, Scalar loop_period) :
+FSNSVelocityIK::FSNSVelocityIK(int dof, double loop_period) :
   SNSVelocityIK(dof, loop_period)
 {
 }
 
 
-Scalar FSNSVelocityIK::getJointVelocity(VectorD *jointVelocity,
+double FSNSVelocityIK::getJointVelocity(Eigen::VectorXd *jointVelocity,
     const std::vector<Task> &sot,
-    const VectorD &jointConfiguration)
+    const Eigen::VectorXd &jointConfiguration)
 {
   // This will only reset member variables if different from previous values
   setNumberOfTasks(sot.size(), sot[0].jacobian.cols());
@@ -45,10 +45,10 @@ Scalar FSNSVelocityIK::getJointVelocity(VectorD *jointVelocity,
 
   //P_0=I
   //dq_0=0
-  MatrixD P = MatrixD::Identity(n_dof, n_dof);
-  *jointVelocity = VectorD::Zero(n_dof, 1);
-  VectorD higherPriorityJointVelocity;
-  MatrixD higherPriorityNull;
+  Eigen::MatrixXd P = Eigen::MatrixXd::Identity(n_dof, n_dof);
+  *jointVelocity = Eigen::VectorXd::Zero(n_dof, 1);
+  Eigen::VectorXd higherPriorityJointVelocity;
+  Eigen::MatrixXd higherPriorityNull;
 
   shapeJointVelocityBound(jointConfiguration);
 
@@ -67,35 +67,35 @@ Scalar FSNSVelocityIK::getJointVelocity(VectorD *jointVelocity,
   return 1.0;
 }
 
-Scalar FSNSVelocityIK::SNSsingle(int priority,
-                                 const VectorD &higherPriorityJointVelocity,
-                                 const MatrixD &higherPriorityNull,
-                                 const MatrixD &jacobian,
-                                 const VectorD &task,
-                                 VectorD *jointVelocity,
-                                 MatrixD *nullSpaceProjector)
+double FSNSVelocityIK::SNSsingle(int priority,
+                                 const Eigen::VectorXd &higherPriorityJointVelocity,
+                                 const Eigen::MatrixXd &higherPriorityNull,
+                                 const Eigen::MatrixXd &jacobian,
+                                 const Eigen::VectorXd &task,
+                                 Eigen::VectorXd *jointVelocity,
+                                 Eigen::MatrixXd *nullSpaceProjector)
 {
   //FIXME: THERE IS A PROBLEM if we use 3 tasks... to be checked
 
   //INITIALIZATION
-  MatrixD JPinverse;  //(J_k P_{k-1})^#
-  Array<Scalar, Dynamic, 1> a, b;  // used to compute the task scaling factor
+  Eigen::MatrixXd JPinverse;  //(J_k P_{k-1})^#
+  Array<double, Dynamic, 1> a, b;  // used to compute the task scaling factor
   bool limit_excedeed;
-  Scalar scalingFactor = 1.0;
+  double scalingFactor = 1.0;
   int mostCriticalJoint;
   bool singularTask = false;
 
-  Scalar best_Scale = -1.0;
-  VectorD best_dq1;
-  VectorD best_dq2;
-  VectorD best_dqw;
+  double best_Scale = -1.0;
+  Eigen::VectorXd best_dq1;
+  Eigen::VectorXd best_dq2;
+  Eigen::VectorXd best_dqw;
   //int best_nSat;
 
-  MatrixD tildeZ;
-  VectorD dq1, dq2, dqw;
+  Eigen::MatrixXd tildeZ;
+  Eigen::VectorXd dq1, dq2, dqw;
 
-  MatrixD bin, zin;
-  Scalar dqw_in;
+  Eigen::MatrixXd bin, zin;
+  double dqw_in;
 
   //initialization
   nSat[priority] = 0;
@@ -106,13 +106,13 @@ Scalar FSNSVelocityIK::SNSsingle(int priority,
   *nullSpaceProjector = tildeZ * tildeZ.transpose();
   dq1 = JPinverse * task;
   dq2 = -JPinverse * jacobian * higherPriorityJointVelocity;
-  dqw = VectorD::Zero(n_dof);
+  dqw = Eigen::VectorXd::Zero(n_dof);
 
   dotQ = higherPriorityJointVelocity + dq1 + dq2;
   a = dq1.array();
   b = dotQ.array() - a;
   getTaskScalingFactor(a, b, S[priority], &scalingFactor, &mostCriticalJoint);
-  //getTaskScalingFactor(a, b, MatrixD::Identity(n_dof, n_dof), &scalingFactor, &mostCriticalJoint);
+  //getTaskScalingFactor(a, b, Eigen::MatrixXd::Identity(n_dof, n_dof), &scalingFactor, &mostCriticalJoint);
 
   if (scalingFactor >= 1.0) {
     // then is clearly the optimum since all joints velocity are computed with the pseudoinverse
@@ -246,14 +246,14 @@ Scalar FSNSVelocityIK::SNSsingle(int priority,
   return 1.0;
 }
 
-void FSNSVelocityIK::getTaskScalingFactor(const Array<Scalar, Dynamic, 1> &a,
-                  const Array<Scalar, Dynamic, 1> &b,
-                  const VectorXi &S, Scalar *scalingFactor,
+void FSNSVelocityIK::getTaskScalingFactor(const Array<double, Dynamic, 1> &a,
+                  const Array<double, Dynamic, 1> &b,
+                  const VectorXi &S, double *scalingFactor,
                   int *mostCriticalJoint)
 {
-  Array<Scalar, Dynamic, 1> Smin, Smax;
-  Scalar temp, smax, smin;
-  Scalar inf = INF;
+  Array<double, Dynamic, 1> Smin, Smax;
+  double temp, smax, smin;
+  double inf = INF;
   int col;
 
   Smin = (dotQmin - b) / a;

--- a/sns_ik_lib/src/fsns_velocity_ik.cpp
+++ b/sns_ik_lib/src/fsns_velocity_ik.cpp
@@ -24,8 +24,7 @@
 
 #include <ros/ros.h>
 
-using namespace Eigen;
-using namespace sns_ik;
+namespace sns_ik {
 
 FSNSVelocityIK::FSNSVelocityIK(int dof, double loop_period) :
   SNSVelocityIK(dof, loop_period)
@@ -39,7 +38,7 @@ double FSNSVelocityIK::getJointVelocity(Eigen::VectorXd *jointVelocity,
 {
   // This will only reset member variables if different from previous values
   setNumberOfTasks(sot.size(), sot[0].jacobian.cols());
-  S.resize(n_tasks, VectorXi::Zero(n_dof));
+  S.resize(n_tasks, Eigen::VectorXi::Zero(n_dof));
 
   // TODO: check that setJointsCapabilities has been already called
 
@@ -79,7 +78,7 @@ double FSNSVelocityIK::SNSsingle(int priority,
 
   //INITIALIZATION
   Eigen::MatrixXd JPinverse;  //(J_k P_{k-1})^#
-  Array<double, Dynamic, 1> a, b;  // used to compute the task scaling factor
+  Eigen::ArrayXd a, b;  // used to compute the task scaling factor
   bool limit_excedeed;
   double scalingFactor = 1.0;
   int mostCriticalJoint;
@@ -99,7 +98,7 @@ double FSNSVelocityIK::SNSsingle(int priority,
 
   //initialization
   nSat[priority] = 0;
-  S[priority] = VectorXi::Zero(n_dof);
+  S[priority] = Eigen::VectorXi::Zero(n_dof);
 
   //compute the base solution
   singularTask = !pinv_QR_Z(jacobian, higherPriorityNull, &JPinverse, &tildeZ);
@@ -246,12 +245,12 @@ double FSNSVelocityIK::SNSsingle(int priority,
   return 1.0;
 }
 
-void FSNSVelocityIK::getTaskScalingFactor(const Array<double, Dynamic, 1> &a,
-                  const Array<double, Dynamic, 1> &b,
-                  const VectorXi &S, double *scalingFactor,
+void FSNSVelocityIK::getTaskScalingFactor(const Eigen::ArrayXd &a,
+                  const Eigen::ArrayXd &b,
+                  const Eigen::VectorXi &S, double *scalingFactor,
                   int *mostCriticalJoint)
 {
-  Array<double, Dynamic, 1> Smin, Smax;
+  Eigen::ArrayXd Smin, Smax;
   double temp, smax, smin;
   double inf = INF;
   int col;
@@ -283,3 +282,5 @@ void FSNSVelocityIK::getTaskScalingFactor(const Array<double, Dynamic, 1> &a,
     (*scalingFactor) = smax;
   }
 }
+
+}  // namespace sns_ik

--- a/sns_ik_lib/src/osns_sm_velocity_ik.cpp
+++ b/sns_ik_lib/src/osns_sm_velocity_ik.cpp
@@ -25,16 +25,16 @@
 using namespace Eigen;
 using namespace sns_ik;
 
-OSNS_sm_VelocityIK::OSNS_sm_VelocityIK(int dof, Scalar loop_period) :
+OSNS_sm_VelocityIK::OSNS_sm_VelocityIK(int dof, double loop_period) :
   OSNSVelocityIK(dof, loop_period),
   m_scaleMargin(0.9)
 {
 }
 
 
-Scalar OSNS_sm_VelocityIK::getJointVelocity(VectorD *jointVelocity,
+double OSNS_sm_VelocityIK::getJointVelocity(Eigen::VectorXd *jointVelocity,
     const std::vector<Task> &sot,
-    const VectorD &jointConfiguration)
+    const Eigen::VectorXd &jointConfiguration)
 {
   // This will only reset member variables if different from previous values
   setNumberOfTasks(sot.size(), sot[0].jacobian.cols());
@@ -43,14 +43,14 @@ Scalar OSNS_sm_VelocityIK::getJointVelocity(VectorD *jointVelocity,
 
   //P_0=I
   //dq_0=0
-  MatrixD P = MatrixD::Identity(n_dof, n_dof);
-  *jointVelocity = VectorD::Zero(n_dof, 1);
-  VectorD higherPriorityJointVelocity;
-  MatrixD higherPriorityNull;
+  Eigen::MatrixXd P = Eigen::MatrixXd::Identity(n_dof, n_dof);
+  *jointVelocity = Eigen::VectorXd::Zero(n_dof, 1);
+  Eigen::VectorXd higherPriorityJointVelocity;
+  Eigen::MatrixXd higherPriorityNull;
 
   shapeJointVelocityBound(jointConfiguration, m_scaleMargin);
 
-  MatrixD PS = MatrixD::Identity(n_dof, n_dof);
+  Eigen::MatrixXd PS = Eigen::MatrixXd::Identity(n_dof, n_dof);
 
   for (int i_task = 0; i_task < n_tasks; i_task++) {  //consider all tasks
     higherPriorityJointVelocity = *jointVelocity;
@@ -71,7 +71,7 @@ Scalar OSNS_sm_VelocityIK::getJointVelocity(VectorD *jointVelocity,
     if (scaleFactors[i_task] > 0.0) {
       if (scaleFactors[i_task] * m_scaleMargin < (1.0)) {
         double taskScale = scaleFactors[i_task] * m_scaleMargin;
-        VectorD scaledTask = sot[i_task].desired * taskScale;
+        Eigen::VectorXd scaledTask = sot[i_task].desired * taskScale;
         scaleFactors[i_task] = SNSsingle(i_task, higherPriorityJointVelocity, higherPriorityNull,
             sot[i_task].jacobian, scaledTask, jointVelocity, &P);
         scaleFactors[i_task] = taskScale;

--- a/sns_ik_lib/src/osns_sm_velocity_ik.cpp
+++ b/sns_ik_lib/src/osns_sm_velocity_ik.cpp
@@ -22,8 +22,7 @@
 
 #include <sns_ik/osns_sm_velocity_ik.hpp>
 
-using namespace Eigen;
-using namespace sns_ik;
+namespace sns_ik {
 
 OSNS_sm_VelocityIK::OSNS_sm_VelocityIK(int dof, double loop_period) :
   OSNSVelocityIK(dof, loop_period),
@@ -85,3 +84,5 @@ double OSNS_sm_VelocityIK::getJointVelocity(Eigen::VectorXd *jointVelocity,
 
   return 1.0;
 }
+
+}  // namespace sns_ik

--- a/sns_ik_lib/src/osns_velocity_ik.cpp
+++ b/sns_ik_lib/src/osns_velocity_ik.cpp
@@ -22,8 +22,7 @@
 
 #include <sns_ik/osns_velocity_ik.hpp>
 
-using namespace Eigen;
-using namespace sns_ik;
+namespace sns_ik {
 
 OSNSVelocityIK::OSNSVelocityIK(int dof, double loop_period) :
   SNSVelocityIK(dof, loop_period)
@@ -77,7 +76,7 @@ double OSNSVelocityIK::SNSsingle(int priority,
   Eigen::MatrixXd temp;
   bool isW_identity;
   Eigen::MatrixXd barP = higherPriorityNull;  // remove the pointer arguments advantage... but I need to modify it
-  Array<double, Dynamic, 1> a, b;  // used to compute the task scaling factor
+  Eigen::ArrayXd a, b;  // used to compute the task scaling factor
   bool limit_excedeed;
   bool singularTask = false;
   bool reachedSingularity = false;
@@ -363,3 +362,5 @@ bool OSNSVelocityIK::isOptimal(int priority, const Eigen::VectorXd& dotQ,
   }
   return isOptimal;
 }
+
+}  // namespace sns_ik

--- a/sns_ik_lib/src/sns_ik.cpp
+++ b/sns_ik_lib/src/sns_ik.cpp
@@ -234,7 +234,7 @@ int SNS_IK::CartToJnt(const KDL::JntArray &q_init, const KDL::Frame &p_in,
 
   int result;
   if (q_bias.rows()) {
-    MatrixD ns_jacobian;
+    Eigen::MatrixXd ns_jacobian;
     std::vector<int> indicies;
     if (!nullspaceBiasTask(q_bias, biasNames, &ns_jacobian, &indicies)) {
       ROS_ERROR("Could not create nullspace bias task");
@@ -273,7 +273,7 @@ int SNS_IK::CartToJntVel(const KDL::JntArray& q_in, const KDL::Twist& v_in,
   std::vector<Task> sot;
   Task task;
   task.jacobian = jacobian.data;
-  task.desired = VectorD::Zero(6);
+  task.desired = Eigen::VectorXd::Zero(6);
   // twistEigenToKDL
   for(size_t i = 0; i < 6; i++)
       task.desired(i) = v_in[i];
@@ -289,7 +289,7 @@ int SNS_IK::CartToJntVel(const KDL::JntArray& q_in, const KDL::Twist& v_in,
       ROS_ERROR("Could not create nullspace bias task");
       return -1;
     }
-    task2.desired = VectorD::Zero(q_bias.rows());
+    task2.desired = Eigen::VectorXd::Zero(q_bias.rows());
     for (size_t ii = 0; ii < q_bias.rows(); ++ii) {
       // This calculates a "nullspace velocity".
       // There is an arbitrary scale factor which will be set by the max scale factor.
@@ -303,8 +303,8 @@ int SNS_IK::CartToJntVel(const KDL::JntArray& q_in, const KDL::Twist& v_in,
   // If the bias is the previous joint velocities, this is velocity damping
   if(q_vel_bias.rows() == q_in.rows()) {
     Task task2;
-    task2.jacobian = MatrixD::Identity(q_vel_bias.rows(), q_vel_bias.rows());
-    task2.desired = VectorD::Zero(q_vel_bias.rows());
+    task2.jacobian = Eigen::MatrixXd::Identity(q_vel_bias.rows(), q_vel_bias.rows());
+    task2.desired = Eigen::VectorXd::Zero(q_vel_bias.rows());
     for (size_t ii = 0; ii < q_vel_bias.rows(); ++ii) {
       task2.desired(ii) = q_vel_bias(ii);
     }
@@ -316,12 +316,12 @@ int SNS_IK::CartToJntVel(const KDL::JntArray& q_in, const KDL::Twist& v_in,
 
 bool SNS_IK::nullspaceBiasTask(const KDL::JntArray& q_bias,
                                const std::vector<std::string>& biasNames,
-                               MatrixD* jacobian,
+                               Eigen::MatrixXd* jacobian,
                                std::vector<int>* indicies)
 {
   ROS_ASSERT_MSG(q_bias.rows() == biasNames.size(), "SNS_IK: Number of joint bias and names differ");
   Task task2;
-  *jacobian = MatrixD::Zero(q_bias.rows(), m_jointNames.size());
+  *jacobian = Eigen::MatrixXd::Zero(q_bias.rows(), m_jointNames.size());
   indicies->resize(q_bias.rows(), 0);
   std::vector<std::string>::iterator it;
   for (size_t ii = 0; ii < q_bias.rows(); ++ii) {
@@ -355,7 +355,7 @@ bool SNS_IK::setMaxJointAcceleration(const KDL::JntArray& accel) {
   return m_ik_vel_solver->setMaxJointAcceleration(accel.data);
 }
 
-bool SNS_IK::getTaskScaleFactors(std::vector<Scalar>& scaleFactors) {
+bool SNS_IK::getTaskScaleFactors(std::vector<double>& scaleFactors) {
   scaleFactors = m_ik_vel_solver->getTasksScaleFactor();
   return m_initialized && !scaleFactors.empty();
 }

--- a/sns_ik_lib/src/sns_ik_math_utils.cpp
+++ b/sns_ik_lib/src/sns_ik_math_utils.cpp
@@ -261,4 +261,4 @@ bool isIdentity(const Eigen::MatrixXd &A) {
   return isIdentity;
 }
 
-} // namespace sns_ikl
+} // namespace sns_ik

--- a/sns_ik_lib/src/sns_ik_math_utils.cpp
+++ b/sns_ik_lib/src/sns_ik_math_utils.cpp
@@ -22,18 +22,19 @@
 
 #include <sns_ik/sns_ik_math_utils.hpp>
 
-using namespace Eigen;
-using namespace sns_ik;
+namespace {
+  const double EPSQ = 1e-10;
+}
 
 namespace sns_ik {
 
-bool pinv(const MatrixD &A, MatrixD *invA, Scalar eps) {
+bool pinv(const Eigen::MatrixXd &A, Eigen::MatrixXd *invA, double eps) {
 
   //A (m x n) usually comes from a redundant task jacobian, therfore we consider m<n
   int m = A.rows() - 1;
-  VectorD sigma;  //vector of singular values
+  Eigen::VectorXd sigma;  //vector of singular values
 
-  JacobiSVD<MatrixD> svd_A(A.transpose(), ComputeThinU | ComputeThinV);
+  Eigen::JacobiSVD<Eigen::MatrixXd> svd_A(A.transpose(), Eigen::ComputeThinU | Eigen::ComputeThinV);
   sigma = svd_A.singularValues();
   if (((m > 0) && (sigma(m) > eps)) || ((m == 0) && (A.array().abs() > eps).any())) {
     for (int i = 0; i <= m; i++) {
@@ -46,13 +47,13 @@ bool pinv(const MatrixD &A, MatrixD *invA, Scalar eps) {
   }
 }
 
-bool pinv_P(const MatrixD &A, MatrixD *invA, MatrixD *P, Scalar eps) {
+bool pinv_P(const Eigen::MatrixXd &A, Eigen::MatrixXd *invA, Eigen::MatrixXd *P, double eps) {
 
   //A (m x n) usually comes from a redundant task jacobian, therfore we consider m<n
   int m = A.rows() - 1;
-  VectorD sigma;  //vector of singular values
+  Eigen::VectorXd sigma;  //vector of singular values
 
-  JacobiSVD<MatrixD> svd_A(A.transpose(), ComputeThinU | ComputeThinV);
+  Eigen::JacobiSVD<Eigen::MatrixXd> svd_A(A.transpose(), Eigen::ComputeThinU | Eigen::ComputeThinV);
   sigma = svd_A.singularValues();
   if (((m > 0) && (sigma(m) > eps)) || ((m == 0) && (A.array().abs() > eps).any())) {
     for (int i = 0; i <= m; i++) {
@@ -67,15 +68,15 @@ bool pinv_P(const MatrixD &A, MatrixD *invA, MatrixD *P, Scalar eps) {
 
 }
 
-bool pinv_damped(const MatrixD &A, MatrixD *invA, Scalar lambda_max, Scalar eps) {
+bool pinv_damped(const Eigen::MatrixXd &A, Eigen::MatrixXd *invA, double lambda_max, double eps) {
 
   //A (m x n) usually comes from a redundant task jacobian, therfore we consider m<n
   int m = A.rows() - 1;
-  VectorD sigma;  //vector of singular values
-  Scalar lambda2;
+  Eigen::VectorXd sigma;  //vector of singular values
+  double lambda2;
   int r = 0;
 
-  JacobiSVD<MatrixD> svd_A(A.transpose(), ComputeThinU | ComputeThinV);
+  Eigen::JacobiSVD<Eigen::MatrixXd> svd_A(A.transpose(), Eigen::ComputeThinU | Eigen::ComputeThinV);
   sigma = svd_A.singularValues();
   if (((m > 0) && (sigma(m) > eps)) || ((m == 0) && (A.array().abs() > eps).any())) {
     for (int i = 0; i <= m; i++) {
@@ -91,8 +92,8 @@ bool pinv_damped(const MatrixD &A, MatrixD *invA, Scalar lambda_max, Scalar eps)
       sigma(i) = (sigma(i) / (sigma(i) * sigma(i) + lambda2));
     }
     //only U till the rank
-    MatrixD subU = svd_A.matrixU().block(0, 0, A.cols(), r);
-    MatrixD subV = svd_A.matrixV().block(0, 0, A.rows(), r);
+    Eigen::MatrixXd subU = svd_A.matrixU().block(0, 0, A.cols(), r);
+    Eigen::MatrixXd subV = svd_A.matrixV().block(0, 0, A.rows(), r);
 
     (*invA) = subU * sigma.asDiagonal() * subV.transpose();
     return false;
@@ -100,15 +101,15 @@ bool pinv_damped(const MatrixD &A, MatrixD *invA, Scalar lambda_max, Scalar eps)
 
 }
 
-bool pinv_damped_P(const MatrixD &A, MatrixD *invA, MatrixD *P, Scalar lambda_max, Scalar eps) {
+bool pinv_damped_P(const Eigen::MatrixXd &A, Eigen::MatrixXd *invA, Eigen::MatrixXd *P, double lambda_max, double eps) {
 
   //A (m x n) usually comes from a redundant task jacobian, therfore we consider m<n
   int m = A.rows() - 1;
   int r = 0;  //rank
-  Scalar lambda2;
+  double lambda2;
 
-  JacobiSVD<MatrixD> svd_A(A.transpose(), ComputeThinU | ComputeThinV);
-  VectorD sigma = svd_A.singularValues();
+  Eigen::JacobiSVD<Eigen::MatrixXd> svd_A(A.transpose(), Eigen::ComputeThinU | Eigen::ComputeThinV);
+  Eigen::VectorXd sigma = svd_A.singularValues();
 
   if (((m > 0) && (sigma(m) > eps)) || ((m == 0) && (A.array().abs() > eps).any())) {
     for (int i = 0; i <= m; i++) {
@@ -119,7 +120,7 @@ bool pinv_damped_P(const MatrixD &A, MatrixD *invA, MatrixD *P, Scalar lambda_ma
     return true;
   } else {
     lambda2 = (1 - (sigma(m) / eps) * (sigma(m) / eps)) * lambda_max * lambda_max;
-    VectorD subSigma = VectorD::Ones(m + 1);
+    Eigen::VectorXd subSigma = Eigen::VectorXd::Ones(m + 1);
     for (int i = 0; i <= m; i++) {
       if (sigma(i) > EPSQ) {
         subSigma(r++) = (sigma(i) / (sigma(i) * sigma(i) + lambda2));
@@ -127,8 +128,8 @@ bool pinv_damped_P(const MatrixD &A, MatrixD *invA, MatrixD *P, Scalar lambda_ma
     }
 
     //only U till the rank
-    MatrixD subU = svd_A.matrixU().block(0, 0, A.cols(), r);
-    MatrixD subV = svd_A.matrixV().block(0, 0, A.rows(), r);
+    Eigen::MatrixXd subU = svd_A.matrixU().block(0, 0, A.cols(), r);
+    Eigen::MatrixXd subV = svd_A.matrixV().block(0, 0, A.rows(), r);
     (*P) = ((*P) - subU * subU.transpose()).eval();
 
     (*invA) = subU * subSigma.head(r).asDiagonal() * subV.transpose();
@@ -137,24 +138,24 @@ bool pinv_damped_P(const MatrixD &A, MatrixD *invA, MatrixD *P, Scalar lambda_ma
 
 }
 
-bool pinv_QR(const MatrixD &A, MatrixD *invA, Scalar eps) {
-  MatrixD At = A.transpose();
-  HouseholderQR < MatrixD > qr = At.householderQr();
+bool pinv_QR(const Eigen::MatrixXd &A, Eigen::MatrixXd *invA, double eps) {
+  Eigen::MatrixXd At = A.transpose();
+  Eigen::HouseholderQR < Eigen::MatrixXd > qr = At.householderQr();
   int m = A.rows();
   //int n = A.cols();
 
-  MatrixD Rt = MatrixD::Zero(m, m);
+  Eigen::MatrixXd Rt = Eigen::MatrixXd::Zero(m, m);
   bool invertible;
 
-  MatrixD hR = (MatrixD) qr.matrixQR();
-  MatrixD Y = ((MatrixD) qr.householderQ()).leftCols(m);
+  Eigen::MatrixXd hR = (Eigen::MatrixXd) qr.matrixQR();
+  Eigen::MatrixXd Y = ((Eigen::MatrixXd) qr.householderQ()).leftCols(m);
 
   //take the useful part of R
   for (int i = 0; i < m; i++) {
     for (int j = 0; j <= i; j++)
       Rt(i, j) = hR(j, i);
   }
-  FullPivLU < MatrixD > invRt(Rt);
+  Eigen::FullPivLU < Eigen::MatrixXd > invRt(Rt);
 
   invertible = fabs(invRt.determinant()) > eps;
 
@@ -167,20 +168,20 @@ bool pinv_QR(const MatrixD &A, MatrixD *invA, Scalar eps) {
 
 }
 
-bool pinv_QR_Z(const MatrixD &A, const MatrixD &Z0, MatrixD *invA, MatrixD *Z, Scalar lambda_max, Scalar eps) {
-  VectorD sigma;  //vector of singular values
-  Scalar lambda2;
+bool pinv_QR_Z(const Eigen::MatrixXd &A, const Eigen::MatrixXd &Z0, Eigen::MatrixXd *invA, Eigen::MatrixXd *Z, double lambda_max, double eps) {
+  Eigen::VectorXd sigma;  //vector of singular values
+  double lambda2;
 
-  MatrixD AZ0t = (A * Z0).transpose();
-  HouseholderQR < MatrixD > qr = AZ0t.householderQr();
+  Eigen::MatrixXd AZ0t = (A * Z0).transpose();
+  Eigen::HouseholderQR < Eigen::MatrixXd > qr = AZ0t.householderQr();
 
   int m = A.rows();
   int p = Z0.cols();
 
-  MatrixD Rt = MatrixD::Zero(m, m);
+  Eigen::MatrixXd Rt = Eigen::MatrixXd::Zero(m, m);
   bool invertible;
-  MatrixD hR = (MatrixD) qr.matrixQR();
-  MatrixD Y = ((MatrixD) qr.householderQ()).leftCols(m);
+  Eigen::MatrixXd hR = (Eigen::MatrixXd) qr.matrixQR();
+  Eigen::MatrixXd Y = ((Eigen::MatrixXd) qr.householderQ()).leftCols(m);
 
   //take the useful part of R
   for (int i = 0; i < m; i++) {
@@ -188,15 +189,15 @@ bool pinv_QR_Z(const MatrixD &A, const MatrixD &Z0, MatrixD *invA, MatrixD *Z, S
       Rt(i, j) = hR(j, i);
   }
 
-  FullPivLU < MatrixD > invRt(Rt);
+  Eigen::FullPivLU < Eigen::MatrixXd > invRt(Rt);
   invertible = fabs(invRt.determinant()) > eps;
 
   if (invertible) {
     *invA = Z0 * Y * invRt.inverse();
-    *Z = Z0 * (((MatrixD) qr.householderQ()).rightCols(p - m));
+    *Z = Z0 * (((Eigen::MatrixXd) qr.householderQ()).rightCols(p - m));
     return true;
   } else {
-    MatrixD R = MatrixD::Zero(m, m);
+    Eigen::MatrixXd R = Eigen::MatrixXd::Zero(m, m);
     //take the useful part of R
     for (int i = 0; i < m; i++) {
       for (int j = i; j < m; j++)  // TODO: is starting at i correct?
@@ -204,7 +205,7 @@ bool pinv_QR_Z(const MatrixD &A, const MatrixD &Z0, MatrixD *invA, MatrixD *Z, S
     }
 
     //perform the SVD of R
-    JacobiSVD<MatrixD> svd_R(R, ComputeThinU | ComputeThinV);
+    Eigen::JacobiSVD<Eigen::MatrixXd> svd_R(R, Eigen::ComputeThinU | Eigen::ComputeThinV);
     sigma = svd_R.singularValues();
     lambda2 = (1 - (sigma(m - 1) / eps) * (sigma(m - 1) / eps)) * lambda_max * lambda_max;
     for (int i = 0; i < m; i++) {
@@ -212,19 +213,19 @@ bool pinv_QR_Z(const MatrixD &A, const MatrixD &Z0, MatrixD *invA, MatrixD *Z, S
     }
     (*invA) = Z0 * Y * svd_R.matrixU() * sigma.asDiagonal() * svd_R.matrixV().transpose();
 
-    *Z = Z0 * (((MatrixD) qr.householderQ()).rightCols(p - m));
+    *Z = Z0 * (((Eigen::MatrixXd) qr.householderQ()).rightCols(p - m));
     return false;
   }
 
 }
 
-bool pinv_forBarP(const MatrixD &W, const MatrixD &P, MatrixD *inv) {
+bool pinv_forBarP(const Eigen::MatrixXd &W, const Eigen::MatrixXd &P, Eigen::MatrixXd *inv) {
 
-  MatrixD tmp;
+  Eigen::MatrixXd tmp;
   bool invertible;
 
   int sizeBarW = (W.diagonal().array() > 0.99).cast<int>().sum();
-  MatrixD barW(sizeBarW, W.cols());
+  Eigen::MatrixXd barW(sizeBarW, W.cols());
   int rowsBarW = 0;
 
   for (int i = 0; i < W.rows(); i++) {
@@ -234,7 +235,7 @@ bool pinv_forBarP(const MatrixD &W, const MatrixD &P, MatrixD *inv) {
   }
 
   tmp = barW * P * barW.transpose();
-  FullPivLU < MatrixD > inversePbar(tmp);
+  Eigen::FullPivLU < Eigen::MatrixXd > inversePbar(tmp);
 
   invertible = inversePbar.isInvertible();
 
@@ -242,12 +243,12 @@ bool pinv_forBarP(const MatrixD &W, const MatrixD &P, MatrixD *inv) {
     (*inv) = P * barW.transpose() * inversePbar.inverse() * barW;
     return true;
   } else {
-    (*inv) = MatrixD::Zero(W.rows(), W.rows());
+    (*inv) = Eigen::MatrixXd::Zero(W.rows(), W.rows());
     return false;
   }
 }
 
-bool isIdentity(const MatrixD &A) {
+bool isIdentity(const Eigen::MatrixXd &A) {
 
   bool isIdentity = true;
   int n = A.rows();

--- a/sns_ik_lib/src/sns_position_ik.cpp
+++ b/sns_ik_lib/src/sns_position_ik.cpp
@@ -69,15 +69,15 @@ bool SNSPositionIK::calcPoseError(const KDL::JntArray& q,
 int SNSPositionIK::CartToJnt(const KDL::JntArray& joint_seed,
                              const KDL::Frame& goal_pose,
                              const KDL::JntArray& joint_ns_bias,
-                             const MatrixD& ns_jacobian,
+                             const Eigen::MatrixXd& ns_jacobian,
                              const std::vector<int>& ns_indicies,
                              const double ns_gain,
                              KDL::JntArray* return_joints,
                              const KDL::Twist& bounds)
 {
-  VectorD jl_low = m_ikVelSolver->getJointLimitLow();
-  VectorD jl_high = m_ikVelSolver->getJointLimitHigh();
-  VectorD maxJointVel = m_ikVelSolver->getJointVelocityMax();
+  Eigen::VectorXd jl_low = m_ikVelSolver->getJointLimitLow();
+  Eigen::VectorXd jl_high = m_ikVelSolver->getJointLimitHigh();
+  Eigen::VectorXd maxJointVel = m_ikVelSolver->getJointVelocityMax();
 
   // initialize variables
   bool solutionFound = false;
@@ -85,20 +85,20 @@ int SNSPositionIK::CartToJnt(const KDL::JntArray& joint_seed,
   KDL::Frame pose_i;
   int n_dof = joint_seed.rows();
   std::vector<Task> sot(1);
-  sot[0].desired = VectorD::Zero(6);
+  sot[0].desired = Eigen::VectorXd::Zero(6);
 
   // If there's a nullspace bias, create a secondary task
   if (joint_ns_bias.rows()) {
     Task nsTask;
     nsTask.jacobian = ns_jacobian;
-    nsTask.desired = VectorD::Zero(joint_ns_bias.rows());
+    nsTask.desired = Eigen::VectorXd::Zero(joint_ns_bias.rows());
     // the desired task to apply the NS bias will change with each iteration
     sot.push_back(nsTask);
   }
 
   double theta;
   double lineErr, rotErr;
-  VectorD qDot(n_dof);
+  Eigen::VectorXd qDot(n_dof);
   KDL::Jacobian jacobian;
   jacobian.resize(q_i.rows());
   KDL::Vector rotAxis, trans;

--- a/sns_ik_lib/src/sns_position_ik.cpp
+++ b/sns_ik_lib/src/sns_position_ik.cpp
@@ -21,7 +21,7 @@
 #include <sns_ik/sns_velocity_ik.hpp>
 #include <iostream>
 
-namespace sns_ik{
+namespace sns_ik {
 
 SNSPositionIK::SNSPositionIK(KDL::Chain chain, std::shared_ptr<SNSVelocityIK> velocity_ik, double eps) :
     m_chain(chain),
@@ -207,12 +207,13 @@ int SNSPositionIK::CartToJnt(const KDL::JntArray& joint_seed,
   }
 
   if (solutionFound) {
-      *return_joints = q_i;
-      //std::cout << "Solution Found in "<< ii <<" iterations!" << std::endl;
-      return 1;  // TODO: return success/fail code
-    } else {
-      //std::cout << "Reached max iterations:, error: " << lineErr << " m, " << rotErr << " rad" << std::endl;
-      return -1;
-    }
+    *return_joints = q_i;
+    //std::cout << "Solution Found in "<< ii <<" iterations!" << std::endl;
+    return 1;  // TODO: return success/fail code
+  } else {
+    //std::cout << "Reached max iterations:, error: " << lineErr << " m, " << rotErr << " rad" << std::endl;
+    return -1;
   }
 }
+
+}  // namespace sns_ik

--- a/sns_ik_lib/src/sns_velocity_ik.cpp
+++ b/sns_ik_lib/src/sns_velocity_ik.cpp
@@ -25,8 +25,7 @@
 #include <ros/ros.h>
 #include <iostream>
 
-using namespace Eigen;
-using namespace sns_ik;
+namespace sns_ik {
 
 SNSVelocityIK::SNSVelocityIK(int dof, double loop_period) :
   n_dof(0),
@@ -204,7 +203,7 @@ double SNSVelocityIK::SNSsingle(int priority,
   Eigen::MatrixXd temp;
   bool isW_identity;
   Eigen::MatrixXd barP = higherPriorityNull;
-  Array<double, Dynamic, 1> a, b;  // used to compute the task scaling factor
+  Eigen::ArrayXd a, b;  // used to compute the task scaling factor
   bool limit_excedeed;
   bool singularTask = false;
   bool reachedSingularity = false;
@@ -349,12 +348,12 @@ double SNSVelocityIK::SNSsingle(int priority,
   return 1.0;
 }
 
-void SNSVelocityIK::getTaskScalingFactor(const Array<double, Dynamic, 1> &a,
-                                         const Array<double, Dynamic, 1> &b,
+void SNSVelocityIK::getTaskScalingFactor(const Eigen::ArrayXd &a,
+                                         const Eigen::ArrayXd &b,
                                          const Eigen::MatrixXd &W, double *scalingFactor,
                                          int *mostCriticalJoint)
 {
-  Array<double, Dynamic, 1> Smin, Smax;
+  Eigen::ArrayXd Smin, Smax;
   double temp, smax, smin;
   double inf = INF;
   int col;
@@ -386,3 +385,5 @@ void SNSVelocityIK::getTaskScalingFactor(const Array<double, Dynamic, 1> &a,
   }
 
 }
+
+}  // namespace sns_ik

--- a/sns_ik_lib/src/sns_velocity_ik.cpp
+++ b/sns_ik_lib/src/sns_velocity_ik.cpp
@@ -28,7 +28,7 @@
 using namespace Eigen;
 using namespace sns_ik;
 
-SNSVelocityIK::SNSVelocityIK(int dof, Scalar loop_period) :
+SNSVelocityIK::SNSVelocityIK(int dof, double loop_period) :
   n_dof(0),
   n_tasks(0),
   m_usePositionLimits(true)
@@ -37,8 +37,8 @@ SNSVelocityIK::SNSVelocityIK(int dof, Scalar loop_period) :
   setLoopPeriod(loop_period);
 }
 
-bool SNSVelocityIK::setJointsCapabilities(const VectorD limit_low, const VectorD limit_high,
-                                          const VectorD maxVelocity, const VectorD maxAcceleration)
+bool SNSVelocityIK::setJointsCapabilities(const Eigen::VectorXd limit_low, const Eigen::VectorXd limit_high,
+                                          const Eigen::VectorXd maxVelocity, const Eigen::VectorXd maxAcceleration)
 {
   if (limit_low.rows() != n_dof || limit_high.rows() != n_dof
       || maxVelocity.rows() != n_dof || maxAcceleration.rows() != n_dof) {
@@ -56,7 +56,7 @@ bool SNSVelocityIK::setJointsCapabilities(const VectorD limit_low, const VectorD
   return true;
 }
 
-bool SNSVelocityIK::setMaxJointVelocity(const VectorD maxVelocity)
+bool SNSVelocityIK::setMaxJointVelocity(const Eigen::VectorXd maxVelocity)
 {
   if (maxVelocity.rows() != n_dof) {
     return false;
@@ -69,7 +69,7 @@ bool SNSVelocityIK::setMaxJointVelocity(const VectorD maxVelocity)
   return true;
 }
 
-bool SNSVelocityIK::setMaxJointAcceleration(const VectorD maxAcceleration)
+bool SNSVelocityIK::setMaxJointAcceleration(const Eigen::VectorXd maxAcceleration)
 {
   if (maxAcceleration.rows() != n_dof) {
     return false;
@@ -82,8 +82,8 @@ void SNSVelocityIK::setNumberOfDOF(int dof)
 {
   if (dof > 0 && dof != n_dof) {
     n_dof = dof;
-    I = MatrixD::Identity(n_dof, n_dof);
-    dotQ = VectorD::Zero(n_dof);
+    I = Eigen::MatrixXd::Identity(n_dof, n_dof);
+    dotQ = Eigen::VectorXd::Zero(n_dof);
   }
 }
 
@@ -93,8 +93,8 @@ void SNSVelocityIK::setNumberOfTasks(int ntasks, int dof)
 
   if (n_tasks != ntasks) {
     n_tasks = ntasks;
-    Scalar scale = 1.0;
-    VectorD dq = VectorD::Zero(n_dof);
+    double scale = 1.0;
+    Eigen::VectorXd dq = Eigen::VectorXd::Zero(n_dof);
 
     W.resize(n_tasks, I);
     scaleFactors.resize(n_tasks, scale);
@@ -103,7 +103,7 @@ void SNSVelocityIK::setNumberOfTasks(int ntasks, int dof)
   }
 }
 
-Scalar SNSVelocityIK::getJointVelocity_STD(VectorD *jointVelocity,
+double SNSVelocityIK::getJointVelocity_STD(Eigen::VectorXd *jointVelocity,
                                            const std::vector<Task> &sot)
 {
   int n_task = sot.size();
@@ -111,9 +111,9 @@ Scalar SNSVelocityIK::getJointVelocity_STD(VectorD *jointVelocity,
 
   //P_0=I
   //dq_0=0
-  MatrixD P = MatrixD::Identity(robotDOF, robotDOF);
-  *jointVelocity = VectorD::Zero(robotDOF, 1);
-  MatrixD tmp, invJ;
+  Eigen::MatrixXd P = Eigen::MatrixXd::Identity(robotDOF, robotDOF);
+  *jointVelocity = Eigen::VectorXd::Zero(robotDOF, 1);
+  Eigen::MatrixXd tmp, invJ;
 
   for (int i_task = 0; i_task < n_task; i_task++) {  //consider all tasks
     // dq_k = dq_{k-1} - (J_k P_{k-1})^# (dx_k - J_k dq_{k-1})
@@ -128,8 +128,8 @@ Scalar SNSVelocityIK::getJointVelocity_STD(VectorD *jointVelocity,
   return 1.0;
 }
 
-Scalar SNSVelocityIK::getJointVelocity(VectorD *jointVelocity, const std::vector<Task> &sot,
-                                       const VectorD &jointConfiguration)
+double SNSVelocityIK::getJointVelocity(Eigen::VectorXd *jointVelocity, const std::vector<Task> &sot,
+                                       const Eigen::VectorXd &jointConfiguration)
 {
   // This will only reset member variables if different from previous values
   setNumberOfTasks(sot.size(), sot[0].jacobian.cols());
@@ -138,10 +138,10 @@ Scalar SNSVelocityIK::getJointVelocity(VectorD *jointVelocity, const std::vector
 
   //P_0=I
   //dq_0=0
-  MatrixD P = MatrixD::Identity(n_dof, n_dof);
-  *jointVelocity = VectorD::Zero(n_dof, 1);
-  VectorD higherPriorityJointVelocity;
-  MatrixD higherPriorityNull;
+  Eigen::MatrixXd P = Eigen::MatrixXd::Identity(n_dof, n_dof);
+  *jointVelocity = Eigen::VectorXd::Zero(n_dof, 1);
+  Eigen::VectorXd higherPriorityJointVelocity;
+  Eigen::MatrixXd higherPriorityNull;
 
   shapeJointVelocityBound(jointConfiguration);
 
@@ -156,7 +156,7 @@ Scalar SNSVelocityIK::getJointVelocity(VectorD *jointVelocity, const std::vector
   return scaleFactors[0];
 }
 
-void SNSVelocityIK::shapeJointVelocityBound(const VectorD &actualJointConfiguration, double margin) {
+void SNSVelocityIK::shapeJointVelocityBound(const Eigen::VectorXd &actualJointConfiguration, double margin) {
 
   // it could be written using the Eigen::Array potentiality
   double step, max, stop;
@@ -189,38 +189,38 @@ void SNSVelocityIK::shapeJointVelocityBound(const VectorD &actualJointConfigurat
   dotQmax *= margin;
 }
 
-Scalar SNSVelocityIK::SNSsingle(int priority,
-                                const VectorD &higherPriorityJointVelocity,
-                                const MatrixD &higherPriorityNull,
-                                const MatrixD &jacobian,
-                                const VectorD &task,
-                                VectorD *jointVelocity,
-                                MatrixD *nullSpaceProjector)
+double SNSVelocityIK::SNSsingle(int priority,
+                                const Eigen::VectorXd &higherPriorityJointVelocity,
+                                const Eigen::MatrixXd &higherPriorityNull,
+                                const Eigen::MatrixXd &jacobian,
+                                const Eigen::VectorXd &task,
+                                Eigen::VectorXd *jointVelocity,
+                                Eigen::MatrixXd *nullSpaceProjector)
 {
   //INITIALIZATION
-  VectorD tildeDotQ;
-  MatrixD projectorSaturated;  //(((I-W_k)*P_{k-1})^#
-  MatrixD JPinverse;  //(J_k P_{k-1})^#
-  MatrixD temp;
+  Eigen::VectorXd tildeDotQ;
+  Eigen::MatrixXd projectorSaturated;  //(((I-W_k)*P_{k-1})^#
+  Eigen::MatrixXd JPinverse;  //(J_k P_{k-1})^#
+  Eigen::MatrixXd temp;
   bool isW_identity;
-  MatrixD barP = higherPriorityNull;
-  Array<Scalar, Dynamic, 1> a, b;  // used to compute the task scaling factor
+  Eigen::MatrixXd barP = higherPriorityNull;
+  Array<double, Dynamic, 1> a, b;  // used to compute the task scaling factor
   bool limit_excedeed;
   bool singularTask = false;
   bool reachedSingularity = false;
-  Scalar scalingFactor = 1.0;
+  double scalingFactor = 1.0;
   int mostCriticalJoint;
   //best solution
-  Scalar bestScale = -1.0;
-  VectorD bestTildeDotQ;
-  MatrixD bestInvJP;
-  VectorD bestDotQn;
-  VectorD dotQn;  //saturate velocity in the null space
+  double bestScale = -1.0;
+  Eigen::VectorXd bestTildeDotQ;
+  Eigen::MatrixXd bestInvJP;
+  Eigen::VectorXd bestDotQn;
+  Eigen::VectorXd dotQn;  //saturate velocity in the null space
 
   //INIT
   W[priority] = I;
   isW_identity = true;
-  dotQn = VectorD::Zero(n_dof);
+  dotQn = Eigen::VectorXd::Zero(n_dof);
 
   //SNS
   int count = 0;
@@ -285,7 +285,7 @@ Scalar SNSVelocityIK::SNSsingle(int priority,
           // the task is not executed
           //ROS_INFO("task not executed: J sing");
           //W[priority]=I;
-          //dotQn=VectorD::Zero(n_dof);
+          //dotQn=Eigen::VectorXd::Zero(n_dof);
           *jointVelocity = higherPriorityJointVelocity;
           *nullSpaceProjector = higherPriorityNull;
         }
@@ -349,14 +349,14 @@ Scalar SNSVelocityIK::SNSsingle(int priority,
   return 1.0;
 }
 
-void SNSVelocityIK::getTaskScalingFactor(const Array<Scalar, Dynamic, 1> &a,
-                                         const Array<Scalar, Dynamic, 1> &b,
-                                         const MatrixD &W, Scalar *scalingFactor,
+void SNSVelocityIK::getTaskScalingFactor(const Array<double, Dynamic, 1> &a,
+                                         const Array<double, Dynamic, 1> &b,
+                                         const Eigen::MatrixXd &W, double *scalingFactor,
                                          int *mostCriticalJoint)
 {
-  Array<Scalar, Dynamic, 1> Smin, Smax;
-  Scalar temp, smax, smin;
-  Scalar inf = INF;
+  Array<double, Dynamic, 1> Smin, Smax;
+  double temp, smax, smin;
+  double inf = INF;
   int col;
 
   Smin = (dotQmin - b) / a;


### PR DESCRIPTION
The key change in this commit is to replace the preprocessor
flag that switched between using float and double precision.

It does not make any change to the implementation or documentation.

There were several small code clean-ups included as well:
- use standard Eigen typedefs (rather than custom)
- remove "using namespace Eigen"
- fix the scoping on local constants
- replace #define INF with numeric_limits<>::max()