### PR TITLE
Unit tests for sns_ik_math_utils

### DIFF
--- a/sns_ik_lib/CMakeLists.txt
+++ b/sns_ik_lib/CMakeLists.txt
@@ -34,15 +34,25 @@ include_directories(include ${catkin_INCLUDE_DIRS} ${EIGEN3_INCLUDE_DIRS} ${oroc
 link_directories(${orocos_kdl_LIBRARY_DIRS})
 install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})
 
-add_library(sns_ik src/sns_ik.cpp
-            src/sns_ik_math_utils.cpp
-            src/sns_velocity_ik.cpp
-            src/sns_position_ik.cpp
-            src/osns_velocity_ik.cpp
-            src/osns_sm_velocity_ik.cpp
+add_library(sns_ik
+            src/fosns_velocity_ik.cpp
             src/fsns_velocity_ik.cpp
-            src/fosns_velocity_ik.cpp)
+            src/osns_sm_velocity_ik.cpp
+            src/osns_velocity_ik.cpp
+            src/sns_ik_data_utilities.cpp
+            src/sns_ik_math_utils.cpp
+            src/sns_ik.cpp
+            src/sns_position_ik.cpp
+            src/sns_velocity_ik.cpp)
 target_link_libraries(sns_ik ${catkin_LIBRARIES} ${orocos_kdl_LIBRARIES})
 
 install(TARGETS sns_ik LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
 install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})
+
+# Unit tests (google framework)
+if (CATKIN_ENABLE_TESTING)
+  catkin_add_gtest(sns_ik_data_utilities_test test/sns_ik_data_utilities_test.cpp)
+  catkin_add_gtest(sns_ik_math_utils_test test/sns_ik_math_utils_test.cpp)
+  target_link_libraries(sns_ik_data_utilities_test ${catkin_LIBRARIES} sns_ik)
+  target_link_libraries(sns_ik_math_utils_test ${catkin_LIBRARIES} sns_ik)
+endif()

--- a/sns_ik_lib/include/sns_ik/sns_ik_data_utilities.hpp
+++ b/sns_ik_lib/include/sns_ik/sns_ik_data_utilities.hpp
@@ -1,0 +1,107 @@
+/*! \file sns_ik_data_utilities.h
+ * \brief Unit Test: sns_ik_math_utils
+ * \author Matthew Kelly
+ */
+/*
+ *    Copyright 2018 Rethink Robotics
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#ifndef SNS_IK_DATA_UTILITIES_H
+#define SNS_IK_DATA_UTILITIES_H
+
+#include <Eigen/Dense>
+
+namespace sns_ik {
+namespace data_util {
+
+/*
+ * This namespace provides a set of functions that are used to generate repeatable pseudo-random
+ * data for unit tests. All functions provide the caller with direct control over the seed that
+ * is used by the random number generator. Passing a seed of zero is used to indicate that the
+ * seed should not be reset, instead letting the random generator progress to the next value in
+ * the sequence. This is useful for generating numbers in a loop, such as for a matrix.
+ */
+
+/*************************************************************************************************/
+
+/*
+ * Generate a pseudo-random value on the range [low, upp], given a starting seed.
+ * Given the same input seed, it will return the same output.
+ * The distribution is uniform between the specified bounds.
+ * @param seed: seed to pass to the RNG on each call
+ *              if seed == 0, then seed is ignored
+ * @param[opt] low: lower bound on the output range  (default 0.0)
+ * @param[opt] upp: upper bound on the output range  (default 1.0)
+ * @return: a pseudorandom value between low and upp  (return low if upp <= low)
+ */
+double getRngDouble(int seed = 0, double low = 0.0, double upp = 1.0);
+
+/*************************************************************************************************/
+
+/*
+ * Generate a pseudo-random value on the range [low, upp], given a starting seed.
+ * Given the same input seed, it will return the same output
+ * @param seed: seed to pass to the RNG on each call
+ *              if seed == 0, then seed is ignored
+ * @param[opt] low: lower bound on the output range  (default 0)
+ * @param[opt] upp: upper bound on the output range  (default 9)
+ * @return: a pseudorandom value between low and upp  (return low if upp <= low)
+ */
+int getRngInt(int seed = 0, int low = 0, int upp = 9);
+
+/*************************************************************************************************/
+
+/*
+ * Generate a pseudo-random boolean value
+ * @param seed: seed to pass to the RNG on each call
+ *              if seed == 0, then seed is ignored
+ * @param trueFrac: "probability" the the function returns true
+ */
+bool getRngBool(int seed, double trueFrac = 0.5) { return getRngDouble(seed, 0.0, 1.0) <= trueFrac; }
+
+/*************************************************************************************************/
+
+/*
+ * Compute a pseudorandom matrix with elements on a specified range.
+ * @param seed: seed to pass to the RNG on each call
+ *              if seed == 0, then seed is ignored
+ * @param nRows: number of rows in the output data
+ * @param nCols: number of columns in the output data
+ * @param[opt] low: lower bound on values in the data  (default: 0.0)
+ * @param[opt] upp: upper bound on values in the data  (default: 1.0)
+ * @return: a random Eigen array of doubles, using a seed to ensure repeatable results.
+ */
+Eigen::MatrixXd getRngMatrixXd(int seed, int nRows, int nCols,
+                               double low = 0.0, double upp = 1.0);
+
+/*************************************************************************************************/
+
+/*
+ * Generate a pseudorandom matrix with elements on a specified range and a specified rank.
+ * This is used to test functions that operate on rank-deficient matricies.
+ * Note: the values in the matrix are on the order of one, but not strictly bounded.
+ * @param seed: seed to pass to the RNG on each call
+ *              if seed == 0, then seed is ignored
+ * @param nRows: number of rows in the output data (must be positive)
+ * @param nCols: number of columns in the output data (must be positive)
+ * @param nRank: the maximum rank that is allowed in the returned matrix
+ * @return: a randomly generated matrix that is at most of rank nRank
+ */
+Eigen::MatrixXd getRngMatrixXdRanked(int seed, int nRows, int nCols, int nRank);
+
+/*************************************************************************************************/
+}  // namespace data_util
+}  // namespace sns_ik
+
+#endif // SNS_IK_DATA_UTILITIES_H

--- a/sns_ik_lib/include/sns_ik/sns_ik_math_utils.hpp
+++ b/sns_ik_lib/include/sns_ik/sns_ik_math_utils.hpp
@@ -2,9 +2,10 @@
  * \brief Math utilities for the SNS IK solvers
  * \author Fabrizio Flacco
  * \author Forrest Rogers-Marcovitz
+ * \author Matthew Kelly
  */
 /*
- *    Copyright 2016 Rethink Robotics
+ *    Copyright 2016-2018 Rethink Robotics
  *
  *    Copyright 2012-2016 Fabrizio Flacco
  *
@@ -29,21 +30,129 @@ namespace sns_ik {
 
 static const double INF = std::numeric_limits<double>::max();
 
-// compute the pseudoinverse of A: it return 0 if A is (row) rank deficient
+/*
+ * FIXME:  Is it possible to avoid doing all of these inverse operations? It is far better
+ *         numerically to solve a linear equation, rather than compute an inverse and then
+ *         perform a matrix multiply.
+ */
+
+/*
+ * FIXME:  There is no input validation on any of this code. If a matrix is input with the wrong
+ *         size then it simply hits an assertion and crashes the thread. This is not desirable
+ *         in a core solver that is running on a robot.
+ */
+
+/*
+ * Compute the pseudoinverse of A using an algorithm based on singular value decomposition.
+ * @param A: input matrix
+ *   FIXME: if A.rows() >= A.cols() causes a failed assertion
+ * @param[out] invA: pseudoinverse of A
+ * @param[opt] eps: singular values smaller than this will be set to zero
+ * @return: true if A is full rank, false if A is rank deficient
+ */
 bool pinv(const Eigen::MatrixXd &A, Eigen::MatrixXd *invA, double eps = 1e-6);
-// compute the pseudoinverse of A: it return 0 if A is (row) rank deficient
-// return also the null space projector P=(P-pinv(A)A)
+
+/*
+ * Compute the pseudoinverse of A along with the nullspace projector matrix.
+ * @param A: input matrix
+ *   FIXME: if A.rows() >= A.cols() causes a failed assertion, but this should be valid input
+ * @param[out] invA: pseudoinverse of A
+ * @param[in/out] P: the nullspace projector matrix:  P = (P - pinv(A)*A)
+ *                   P.rows() == P.cols() = A.cols() is required
+ *                   P should be initialized with the identity matrix
+ * @param[opt] eps: singular values smaller than this will be set to zero
+ * @return: true if A is full rank, false if A is rank deficient
+ */
 bool pinv_P(const Eigen::MatrixXd &A, Eigen::MatrixXd *invA, Eigen::MatrixXd *P, double eps = 1e-6);
-// compute the pseudoinverse of A: it return 0 if A is (row) rank deficient
-bool pinv_damped(const Eigen::MatrixXd &A, Eigen::MatrixXd *invA, double lambda_max = 1e-6,
-                 double eps = 1e-6);
+
+/*
+ * Compute the pseudoinverse of A along with the nullspace projector matrix.
+ * @param A: input matrix
+ *   FIXME: if A.rows() >= A.cols() causes a failed assertion, but this should be valid input
+ * @param[out] invA: pseudoinverse of A
+ * @param[in/out] P: the nullspace projector matrix:  P = (P - pinv(A)*A)
+ *                   P.rows() == P.cols() = A.cols() is required
+ *                   P should be initialized with the identity matrix
+ * @param[opt] lambda_max: damping parameter for the damped pseudoinverse
+ * @param[opt] eps: singular values smaller than this will be set to zero
+ * @return: true if A is full rank, false if A is rank deficient
+ */
 bool pinv_damped_P(const Eigen::MatrixXd &A, Eigen::MatrixXd *invA, Eigen::MatrixXd *P,
                    double lambda_max = 1e-6, double eps = 1e-6);
-bool pinv_forBarP(const Eigen::MatrixXd &W, const Eigen::MatrixXd &P, Eigen::MatrixXd *inv);
-bool pinv_QR_Z(const Eigen::MatrixXd &A, const Eigen::MatrixXd &Z0, Eigen::MatrixXd *invA,
-               Eigen::MatrixXd *Z, double lambda_max = 1e-6, double eps = 1e-6);
+
+/*
+ * Compute the pseudoinverse of A using an algorithm based on QR decomposition
+ * @param A: input matrix
+ *   FIXME: if A.rows() >= A.cols() causes a failed assertion, but this should be valid input
+ * @param[out] invA: pseudoinverse of A
+ * @param[opt] eps: singular values smaller than this will be set to zero
+ * @return: true if A is full rank, false if A is rank deficient
+ */
 bool pinv_QR(const Eigen::MatrixXd &A, Eigen::MatrixXd *invA, double eps = 1e-6);
 
+/*
+ * This code is used to compute the equations 6-10 in the main SNS-IK paper.
+ * The variable names are taken to match those in the paper, letting k = 1.
+ * It seems that the output of this code is dependent on the particular type of QR factorization
+ * routine in Eigen, in this case: HouseholderQR.
+ *
+ * Here are the relationships between the inputs and the outputs, written in Matlab pseudocode
+ * (J1*Za0)' = [Ya1, Z1] * [Ra1; 0];  % QR decomposition
+ * Jstar = Za0*Ya1*inv(Ra1');  % projected inverse task jacobian
+ * Za1 = Za0*Z1;  % updated nullspace projector
+ *
+ * @param J1:  task jacobian with size [m, n], with m <= n
+ * @param Za0:  previous nullSpaceProjector with size [n, n]
+ * @param[out] Jstar:  (not named in the paper)
+ * @param[out] Za1:  new nullSpaceProjector
+ * @param[opt] lambda_max: damping parameter for one of the inverses
+ * @param[opt] eps: singular values smaller than this will be set to zero
+ */
+bool pinv_QR_Z(const Eigen::MatrixXd &J1, const Eigen::MatrixXd &Za0, Eigen::MatrixXd *Jstar,
+               Eigen::MatrixXd *Za1, double lambda_max = 1e-6, double eps = 1e-6);
+
+/*
+ * This function computes the inverse of the projection of the P matrix onto the dimensions that
+ * are selected by W. One way to think about this would be to reorder the dimensions such that
+ * the matrix W is block diagonal, with the upper left block the identify matrix and the lower
+ * right block all zeros. Then compute the inverse of the block in the reordered version of
+ * P, while setting all other entries to zero. The final step is to reorder the dimesions again.
+ *
+ * This function is related to the concepts in equations 16-17 of the main paper.
+ *
+ * These concepts are perhaps best expressed in Matlab code:
+ *    % This code is optimized for readability - this is a bad numerical implementation
+ *    n = 10;  % number of dimensions in P
+ *    s = rand(1, n)>0.4;  % selection vector (true == use this joint)
+ *    W = diag(s);  % selection matrix (square)
+ *    P = randn(length(s));  % random square input matrix
+ *    K = W(s, :);  % sub-space selection matrix (rectangular)
+ *    M = K*P*K';  % sub-matrix of P, in active joints
+ *    A = inv(M);  % inverse of the sub-matrix  % note: avoid doing this!  (prefer linear solve)
+ *    B = K'*A*K;  % project B back into the original space
+ *    zero = eye(sum(s)) - K*P*B*K';  % condition to test
+ *
+ *   FIXME: remove direct inverse, replace with linear solve
+ *   FIXME: remove hard-coded constants embedded in code
+ *   FIXME: is it possible to replace W with a boolean vector?
+ *
+ * @param W: selection matrix, diagonal entries are either zero or one, other entries are zero.
+      W(i, i) == 1 indicates that dimension i should be used, otherwise ignore dimension i
+ * @param P: project matrix, must be square. P.rows() == P.cols() == W.cols()
+ * @param[out] B: the inverse of the sub-matrix of P that is selected by W
+ *      if return false, then B is zeros
+ *      M = select(P); // smaller square matrix, size == number of non-zero diagonal entries in W
+ *      K = backProject(inverse(M)); // compute the inverse of M and project back to size of P
+ *      C = P*K;
+ * @return: true iff inversePbar is invertible
+ */
+bool pinv_forBarP(const Eigen::MatrixXd &W, const Eigen::MatrixXd &P, Eigen::MatrixXd *C);
+
+/*
+ * @return true iff the diagonal elements are near unity
+ *   FIXME: if A.rows() >= A.cols() causes a failed assertion
+ *   FIXME: if A(i,i) > 1.0, then this function returns the wrong answer
+ */
 bool isIdentity(const Eigen::MatrixXd &A);
 
 }  // namespace sns_ik

--- a/sns_ik_lib/src/sns_ik_data_utilities.cpp
+++ b/sns_ik_lib/src/sns_ik_data_utilities.cpp
@@ -1,0 +1,76 @@
+/*
+ *    Copyright 2018 Rethink Robotics
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <sns_ik/sns_ik_data_utilities.hpp>
+
+#include <random>
+
+namespace sns_ik {
+namespace data_util {
+
+/*************************************************************************************************/
+
+double getRngDouble(int seed, double low, double upp) {
+  static std::mt19937 gen;  // mersenne-twister pseudo-random number generator
+  if (upp <= low) { return low; } // catch edge case
+  if (seed > 0) { gen.seed(seed); }  // set the seed so that we get repeatable outputs for the test
+  static std::uniform_real_distribution<> dis(0.0, 1.0);
+  return low + (upp - low) * dis(gen);  // sample the RNG and then map to the range [0, 1]
+}
+
+/*************************************************************************************************/
+
+int getRngInt(int seed, int low, int upp) {
+  if (upp <= low) { return low; } // catch edge case
+  if (seed != 0) { srand(seed); }  // set the seed so that we get repeatable outputs
+  return rand() % (upp-low) + low;  // not a true uniform distribution, but close enough
+}
+
+/*************************************************************************************************/
+
+Eigen::MatrixXd getRngMatrixXd(int seed, int nRows, int nCols, double low, double upp)
+{
+  Eigen::MatrixXd data(nRows, nCols);
+  if (nRows < 1 || nCols < 1) { return data; }
+  for (int iRow = 0; iRow < nRows; iRow++) {
+    for (int iCol = 0; iCol < nCols; iCol++) {
+      if (iRow == 0 && iCol == 0) {  // Set the seed in the RNG on first call
+       data(iRow, iCol) = getRngDouble(seed, low, upp);
+      } else {  // Do not update the seed
+       data(iRow, iCol) = getRngDouble(0, low, upp);  // 0 == do not update seed
+      }
+    }
+  }
+  return data;
+}
+
+/*************************************************************************************************/
+
+Eigen::MatrixXd getRngMatrixXdRanked(int seed, int nRows, int nCols, int nRank)
+{
+  nRows = std::max(nRows, 1);
+  nCols = std::max(nCols, 1);
+  nRank = std::max(nRank, 1);
+  nRank = std::min({nRows, nCols, nRank});
+  Eigen::MatrixXd A = getRngMatrixXd(seed + 67394, nRows, nRank, -1.0, 1.0);
+  Eigen::MatrixXd B = getRngMatrixXd(seed + 78895, nRank, nCols, -1.0, 1.0);
+  Eigen::MatrixXd X = A * B;
+  return X;
+}
+
+/*************************************************************************************************/
+
+}  // namespace data_util
+}  // namespace sns_ik

--- a/sns_ik_lib/src/sns_ik_math_utils.cpp
+++ b/sns_ik_lib/src/sns_ik_math_utils.cpp
@@ -68,39 +68,6 @@ bool pinv_P(const Eigen::MatrixXd &A, Eigen::MatrixXd *invA, Eigen::MatrixXd *P,
 
 }
 
-bool pinv_damped(const Eigen::MatrixXd &A, Eigen::MatrixXd *invA, double lambda_max, double eps) {
-
-  //A (m x n) usually comes from a redundant task jacobian, therfore we consider m<n
-  int m = A.rows() - 1;
-  Eigen::VectorXd sigma;  //vector of singular values
-  double lambda2;
-  int r = 0;
-
-  Eigen::JacobiSVD<Eigen::MatrixXd> svd_A(A.transpose(), Eigen::ComputeThinU | Eigen::ComputeThinV);
-  sigma = svd_A.singularValues();
-  if (((m > 0) && (sigma(m) > eps)) || ((m == 0) && (A.array().abs() > eps).any())) {
-    for (int i = 0; i <= m; i++) {
-      sigma(i) = 1.0 / sigma(i);
-    }
-    (*invA) = svd_A.matrixU() * sigma.asDiagonal() * svd_A.matrixV().transpose();
-    return true;
-  } else {
-    lambda2 = (1 - (sigma(m) / eps) * (sigma(m) / eps)) * lambda_max * lambda_max;
-    for (int i = 0; i <= m; i++) {
-      if (sigma(i) > EPSQ)
-        r++;
-      sigma(i) = (sigma(i) / (sigma(i) * sigma(i) + lambda2));
-    }
-    //only U till the rank
-    Eigen::MatrixXd subU = svd_A.matrixU().block(0, 0, A.cols(), r);
-    Eigen::MatrixXd subV = svd_A.matrixV().block(0, 0, A.rows(), r);
-
-    (*invA) = subU * sigma.asDiagonal() * subV.transpose();
-    return false;
-  }
-
-}
-
 bool pinv_damped_P(const Eigen::MatrixXd &A, Eigen::MatrixXd *invA, Eigen::MatrixXd *P, double lambda_max, double eps) {
 
   //A (m x n) usually comes from a redundant task jacobian, therfore we consider m<n

--- a/sns_ik_lib/test/sns_ik_data_utilities_test.cpp
+++ b/sns_ik_lib/test/sns_ik_data_utilities_test.cpp
@@ -1,0 +1,149 @@
+/*! \file fosns_velocity_ik.hpp
+ * \brief Unit Test: sns_ik_math_utils
+ * \author Matthew Kelly
+ *
+ * Unit tests for the sns_ik_data_utilities suite of functions.
+ */
+/*
+ *    Copyright 2018 Rethink Robotics
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <Eigen/Dense>
+
+#include <sns_ik/sns_ik_data_utilities.hpp>
+
+/*************************************************************************************************/
+
+/*
+ * Unit test for the method sns_ik::data_util::getRngDouble_test()
+ */
+TEST(sns_ik_data_utils, getRngDouble_test)
+{
+  // Check repeatability
+  double tol = 1e-12;
+  EXPECT_NEAR(sns_ik::data_util::getRngDouble(15381, -3, 8), 6.0196095670444016, tol);
+  EXPECT_NEAR(sns_ik::data_util::getRngDouble(22247, -3, 8), 2.8762760491777524, tol);
+  EXPECT_NEAR(sns_ik::data_util::getRngDouble(75855, -3, 8), -2.7505936842008896, tol);
+  EXPECT_NEAR(sns_ik::data_util::getRngDouble(83586, -3, 8), 4.3001619259988875, tol);
+  EXPECT_NEAR(sns_ik::data_util::getRngDouble(0, -3, 8), 0.10624858533393144, tol);
+  EXPECT_NEAR(sns_ik::data_util::getRngDouble(0, -3, 8), 4.6314850369164899, tol);
+  EXPECT_NEAR(sns_ik::data_util::getRngDouble(0, -3, 8), 6.0602696997106875, tol);
+
+  // Check bounds:
+  for (int i = 0; i < 49; i++) {
+    double low = sns_ik::data_util::getRngDouble(14469 + i, -5, 20);
+    double upp = low + sns_ik::data_util::getRngDouble(25209 + i, 1e-6, 10);
+    ASSERT_LT(low, upp);
+    double x = sns_ik::data_util::getRngDouble(0, low, upp);
+    ASSERT_LE(low, x);
+    ASSERT_LE(x, upp);
+  }
+}
+
+/*************************************************************************************************/
+
+// Unit test for sns_ik::data_util::getRngInt_test()
+TEST(sns_ik_data_utils, getRngInt_test)
+{
+  // Check repeatability
+  EXPECT_EQ(sns_ik::data_util::getRngInt(81656, 0, 8), 7);
+  EXPECT_EQ(sns_ik::data_util::getRngInt(20001, 1, 1), 1);  // edge case test
+  EXPECT_EQ(sns_ik::data_util::getRngInt(87349, 2, 1), 2);  // edge case test
+  EXPECT_EQ(sns_ik::data_util::getRngInt(46785, 0, 80), 33);
+  EXPECT_EQ(sns_ik::data_util::getRngInt(0, -2, 8), 7);
+  EXPECT_EQ(sns_ik::data_util::getRngInt(0, 2, 7), 6);
+  EXPECT_EQ(sns_ik::data_util::getRngInt(0, 2, 7), 5);
+
+  // Check bounds:
+  for (int i = 0; i < 49; i++) {
+    int low = sns_ik::data_util::getRngInt(85987 + i, -5, 20);
+    int upp = low + sns_ik::data_util::getRngInt(40075 + i, 0, 10);
+    ASSERT_LE(low, upp);
+    int x = sns_ik::data_util::getRngInt(0, low, upp);
+    ASSERT_LE(low, x);
+    ASSERT_LE(x, upp);
+  }
+}
+
+/*************************************************************************************************/
+// Unit test for sns_ik::data_util::getRngMatrixXd
+TEST(sns_ik_data_utilities, getRngMatrixXd_test)
+{
+  // Check repeatability:
+  double tol = 1e-12;
+  Eigen::MatrixXd X;
+  X = sns_ik::data_util::getRngMatrixXd(46215, 3, 9, -0.2, 0.9);
+  EXPECT_NEAR(X(2, 5), 0.58648152100546125, tol);
+  EXPECT_NEAR(X(1, 4), 0.75799866897218138, tol);
+  X = sns_ik::data_util::getRngMatrixXd(0, 3, 6, -0.9, 3.9);
+  EXPECT_NEAR(X(2, 3), 0.36170151893839109, tol);
+  EXPECT_NEAR(X(1, 2), 1.3053972293469402, tol);
+  X = sns_ik::data_util::getRngMatrixXd(0, 3, 6, -0.9, 3.9);
+  EXPECT_NEAR(X(2, 3), 1.0321424117752471, tol);
+  EXPECT_NEAR(X(1, 2), 1.3353510589525368, tol);
+  // Check bounds and size:
+  int seed = 26569;
+  for (int i = 0; i < 15; i++) {
+    // Generate the parameters for the matrix
+    seed++;
+    int nRows = sns_ik::data_util::getRngInt(seed + 20817, 1, 9);
+    int nCols = sns_ik::data_util::getRngInt(seed + 66461, 1, 9);
+    int nRank = sns_ik::data_util::getRngInt(seed + 77126, 1, 9);
+    double low = sns_ik::data_util::getRngDouble(seed + 30185, -5, 20);
+    double upp = low + sns_ik::data_util::getRngDouble(seed + 45177, 1e-6, 10);
+    X = sns_ik::data_util::getRngMatrixXd(seed + 10883, nRows, nCols, low, upp);
+    ASSERT_EQ(X.rows(), nRows);
+    ASSERT_EQ(X.cols(), nCols);
+    ASSERT_GE(X.minCoeff(), low);
+    ASSERT_LE(X.maxCoeff(), upp);
+  }
+}
+
+/*************************************************************************************************/
+
+// Unit test for sns_ik::data_util::getRngMatrixXdRanked()
+TEST(sns_ik_data_utilities, getRngMatrixXdRanked_test)
+{
+  int seed = 95314;
+  for (int i = 0; i < 15; i++) {
+
+    // Generate the parameters for the matrix
+    seed++;
+    int nRows = sns_ik::data_util::getRngInt(seed + 94522, 1, 9);
+    int nCols = sns_ik::data_util::getRngInt(seed + 67168, 1, 9);
+    int nRank = sns_ik::data_util::getRngInt(seed + 86769, 1, 9);
+
+    // Generate the matrix
+    Eigen::MatrixXd X = sns_ik::data_util::getRngMatrixXdRanked(seed + 12880, nRows, nCols, nRank);
+
+    // Check the rank:
+    nRank = std::min({nRows, nCols, nRank});
+    Eigen::ColPivHouseholderQR<Eigen::MatrixXd> decomp(X);
+    ASSERT_LE(decomp.rank(), nRank);
+
+    // Check the size:
+    ASSERT_EQ(X.rows(), nRows);
+    ASSERT_EQ(X.cols(), nCols);
+  }
+}
+
+/*************************************************************************************************/
+
+// Run all the tests that were declared with TEST()
+int main(int argc, char **argv){
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/sns_ik_lib/test/sns_ik_math_utils_test.cpp
+++ b/sns_ik_lib/test/sns_ik_math_utils_test.cpp
@@ -1,0 +1,346 @@
+/*! \file fosns_velocity_ik.hpp
+ * \brief Unit Test: sns_ik_math_utils
+ * \author Matthew Kelly
+ */
+/*
+ *    Copyright 2018 Rethink Robotics
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <Eigen/Dense>
+#include <ros/console.h>
+
+#include <sns_ik/sns_ik_data_utilities.hpp>
+#include <sns_ik/sns_ik_math_utils.hpp>
+
+/*************************************************************************************************
+ *                               Utilities Functions                                             *
+ *************************************************************************************************/
+
+/*
+ * Element-wise check that two matricies are equal to within some tolerance
+ * @param A: first input matrix
+ * @param B: second input matrix
+ * @param tol: tolerance on equality checks
+ */
+void checkEqualMatricies(const Eigen::MatrixXd& A, const Eigen::MatrixXd& B, double tol)
+{
+  ASSERT_EQ(A.rows(), B.rows());
+  ASSERT_EQ(A.cols(), B.cols());
+  int n = A.rows();
+  int m = A.cols();
+  for (int i = 0; i < n; i++) {
+    for (int j = 0; j < m; j++) {
+      ASSERT_NEAR(A(i,j), B(i,j), tol);
+    }
+  }
+}
+
+/*************************************************************************************************/
+
+/*
+ * Check that two matricies are related by a Moore-Penrose pseudoinverse, to within tol.
+ * X = pinv(A)
+ * @param A: matrix A
+ * @param X: the pseudoinverse of matrix A
+ * @param tol: tolerance on element-wise matrix equality check
+ */
+void checkPseudoInverse(const Eigen::MatrixXd& A, const Eigen::MatrixXd& X, double tol)
+{
+  checkEqualMatricies(A*X*A, A, tol);
+  checkEqualMatricies(X*A*X, X, tol);
+  Eigen::MatrixXd XA = X*A;
+  Eigen::MatrixXd AX = A*X;
+  checkEqualMatricies(XA, XA.transpose(), tol);
+  checkEqualMatricies(AX, AX.transpose(), tol);
+}
+
+/*************************************************************************************************/
+
+/*
+ * Compute the matrices that form the block-matrix QR decomposition of A = [Y, Z]*[R; 0]
+ * @param A: matrix of size [n x m] to perform decomposition of
+ * @param[out] Y: left block of Q in the QR decomposition of A
+ * @param[out] Z: right block of Q in the QR decomposition of A
+ * @param[out] R: upper (non-zero) block of R in the QR decomposition of A
+ */
+void qrBlockDecompose(const Eigen::MatrixXd& A,
+                      Eigen::MatrixXd* Y, Eigen::MatrixXd* Z, Eigen::MatrixXd* R)
+{
+  int n = A.rows();
+  int m = A.cols();
+  Eigen::HouseholderQR<Eigen::MatrixXd> qr(A);  // Tests fail with other QR decompositions
+  *Y = ((Eigen::MatrixXd) qr.householderQ()).leftCols(m);
+  *Z = ((Eigen::MatrixXd) qr.householderQ()).rightCols(n-m);
+  *R = qr.matrixQR().topLeftCorner(m, m).template triangularView<Eigen::Upper>();
+}
+
+/*************************************************************************************************
+ *                                        Tests                                                  *
+ *************************************************************************************************/
+
+/*
+ * Unit test for the method sns_ik::pinv()
+ * TODO: pass arbitrary size matricies into pinv() once the code is fixed to support it
+ */
+TEST(sns_ik_math_utils, pinv_test)
+{
+  // Run standard tests
+  double tolSvd = 1e-8;  // svd minimum value tolerance
+  double tolMat = 1e-6;  // tolerance for matrix equality check
+  Eigen::MatrixXd X;  // pinv(A)
+  int seed = 97460;
+  double low = -2.0;  double upp = 2.0;  // bounds on values in the A matrix
+  for (int i = 0; i < 25; i++) {
+    // generate test data
+    seed++;
+    int nCol = sns_ik::data_util::getRngInt(seed + 50322, 3, 9);
+    int nRow = sns_ik::data_util::getRngInt(seed + 87288, 2, (nCol-1));  // TODO: any number of rows
+    // Decide whether to use a full-rank or rank degenerate case
+    bool fullRank = sns_ik::data_util::getRngBool(seed + 96717, 0.85);  // usually full rank
+    if (fullRank) {  // generate and test for a full-rank input
+      Eigen::MatrixXd A = sns_ik::data_util::getRngMatrixXd(seed + 81068, nRow, nCol, low, upp);
+      ASSERT_TRUE(sns_ik::pinv(A, &X, tolSvd));
+      checkPseudoInverse(A, X, tolMat);
+    } else {  // generate an test for a rank-deficient input
+      int nRank = std::min(nRow, nCol) - 1;
+      Eigen::MatrixXd A = sns_ik::data_util::getRngMatrixXdRanked(seed + 81068, nRow, nCol, nRank);
+      ASSERT_FALSE(sns_ik::pinv(A, &X, tolSvd));
+    }
+  }
+}
+
+/*************************************************************************************************/
+
+/*
+ * Unit test for pinv_P()
+ * TODO: pass arbitrary size matricies into pinv() once the code is fixed to support it
+ */
+TEST(sns_ik_math_utils, pinv_P_test)
+{
+  // Run standard tests
+  double tolSvd = 1e-8;  // svd minimum value tolerance
+  double tolMat = 1e-6;  // tolerance for matrix equality check
+  Eigen::MatrixXd X;  // pinv(A)
+  int seed = 84658;
+  double low = -2.0;  double upp = 2.0;  // bounds on values in the A and P matrix
+  Eigen::MatrixXd A;
+  for (int iTest = 0; iTest < 25; iTest++) {
+    // generate test data
+    seed++;
+    int nCol = sns_ik::data_util::getRngInt(seed + 80226, 3, 9);
+    int nRow = sns_ik::data_util::getRngInt(seed + 49166, 2, (nCol-1));  // TODO: any number of rows
+    Eigen::MatrixXd P = sns_ik::data_util::getRngMatrixXd(seed + 70730, nCol, nCol, low, upp);
+    Eigen::MatrixXd PP = P;  // Projected P matrix
+    // Decide whether to use a full-rank or rank degenerate case
+    bool fullRank = sns_ik::data_util::getRngBool(seed + 11052, 0.85);  // usually full rank
+    if (fullRank) {  // generate and test for a full-rank input
+      A = sns_ik::data_util::getRngMatrixXd(seed + 75011, nRow, nCol, low, upp);
+      ASSERT_TRUE(sns_ik::pinv_P(A, &X, &PP, tolSvd));
+      checkPseudoInverse(A, X, tolMat);
+      checkEqualMatricies(PP, P - X*A, tolMat);
+    } else {  // generate an test for a rank-deficient input
+      int nRank = std::min(nRow, nCol) - 1;
+      A = sns_ik::data_util::getRngMatrixXdRanked(seed + 91579, nRow, nCol, nRank);
+      ASSERT_FALSE(sns_ik::pinv_P(A, &X, &PP, tolSvd));
+    }
+  }
+}
+
+/*************************************************************************************************/
+
+/*
+ * Unit test for pinv_damped_P()
+ * TODO: pass arbitrary size matricies into pinv_damped_P() once the code is fixed to support it
+ */
+TEST(sns_ik_math_utils, pinv_damped_P_test)
+{
+  // Run standard tests
+  double tolSvd = 1e-6;  // svd minimum value tolerance
+  double tolMat = 1e-5;  // tolerance for matrix equality check
+  double lambda = 1e-6;  // damping parameter for damped pseudoinverse
+  Eigen::MatrixXd X;  // pinv(A)
+  int seed = 81012;
+  double low = -2.0;  double upp = 2.0;  // bounds on values in the A and P matrix
+  Eigen::MatrixXd A;
+  for (int iTest = 0; iTest < 25; iTest++) {
+    // generate test data
+    int nCol = sns_ik::data_util::getRngInt(seed + 82956, 3, 9);
+    int nRow = sns_ik::data_util::getRngInt(seed + 44438, 2, (nCol-1));  // TODO: any number of rows
+    Eigen::MatrixXd P = sns_ik::data_util::getRngMatrixXd(seed + 54852, nCol, nCol, low, upp);
+    Eigen::MatrixXd PP = P;  // Projected P matrix
+    // Decide whether to use a full-rank or rank degenerate case
+    bool fullRank = sns_ik::data_util::getRngBool(seed + 86532, 0.85);  // usually full rank
+    if (fullRank) {  // generate and test for a full-rank input
+      A = sns_ik::data_util::getRngMatrixXd(seed + 75312, nRow, nCol, low, upp);
+      ASSERT_TRUE(sns_ik::pinv_damped_P(A, &X, &PP, lambda, tolSvd));
+      checkPseudoInverse(A, X, tolMat);
+    } else {  // generate an test for a rank-deficient input
+      int nRank = std::min(nRow, nCol) - 1;
+      A = sns_ik::data_util::getRngMatrixXdRanked(seed + 88433, nRow, nCol, nRank);
+      ASSERT_FALSE(sns_ik::pinv_damped_P(A, &X, &PP, lambda, tolSvd));
+    }
+    checkEqualMatricies(PP, P - X*A, tolMat);
+  }
+}
+
+/*************************************************************************************************/
+
+TEST(sns_ik_math_utils, pinv_forBarP_test)
+{
+  double tolMat = 1e-6;  // tolerance for matrix equality check
+  int seed = 36230;
+  double low = -2.0;  double upp = 2.0;  // bounds on values in the A and P matrix
+  Eigen::MatrixXd W, C, K, P;
+  for (int iTest = 0; iTest < 40; iTest++) {
+    seed++;
+
+    // Compute the selection matrix (W) and data matrix (P)
+    int nDim = sns_ik::data_util::getRngInt(seed + 85004, 2, 11);
+    std::vector<bool> selectionVector(nDim);
+    for (int iDim = 0; iDim < nDim; iDim++) {
+      selectionVector[iDim] = sns_ik::data_util::getRngBool(0, 0.6);
+    }
+    int nnz = 0; // number of non-zero elements
+    for (int iDim = 0; iDim < nDim; iDim++) {
+      if (selectionVector[iDim]) { nnz++; }
+    }
+    if (nnz == 0) { selectionVector[0] = true;  nnz = 1; }
+    W = Eigen::MatrixXd::Zero(nDim, nDim);  // selection matrix
+    for (int iDim = 0; iDim < nDim; iDim++) {
+      if (selectionVector[iDim]) { W(iDim, iDim) = 1.0; }
+    }
+
+    // Decide whether to use a full-rank or rank degenerate case
+    bool fullRank = sns_ik::data_util::getRngBool(seed + 86532, 0.7);  // usually full rank
+    bool smallNullSpace = nDim - nnz < 2;  // true if the nullspace has fewer than two dimensions
+    if (fullRank || smallNullSpace) {  // generate and test for a full-rank input
+      P = sns_ik::data_util::getRngMatrixXd(seed + 47524, nDim, nDim, low, upp);
+
+      // Compute the sub-selection matrix:
+      K = Eigen::MatrixXd::Zero(nnz, nDim);
+      int idx = 0;
+      for (int iDim = 0; iDim < nDim; iDim++) {
+        if (selectionVector[iDim]) { K(idx, iDim) = 1.0; idx++; }
+      }
+
+      // Call the function to be tested:
+      ASSERT_TRUE(sns_ik::pinv_forBarP(W, P, &C));
+      // Check that the result is valid:
+      checkEqualMatricies(Eigen::MatrixXd::Identity(nnz, nnz), K*C*(K.transpose()), tolMat);
+
+    } else { // use the rank-deficient case
+        int nRank = 1;
+        P = sns_ik::data_util::getRngMatrixXdRanked(seed + 20880, nDim, nDim, nRank);
+
+        // Call the function to be tested:
+        ASSERT_FALSE(sns_ik::pinv_forBarP(W, P, &C));
+        // Check that the result is valid:
+        checkEqualMatricies(Eigen::MatrixXd::Zero(nDim, nDim), C, tolMat);
+    }
+  }
+}
+
+/*************************************************************************************************/
+
+/*
+ * Unit test for the method sns_ik::pinv_QR()
+ * TODO: pass arbitrary size matricies into pinv_QR() once the code is fixed to support it
+ */
+TEST(sns_ik_math_utils, pinv_QR_test)
+{
+  // Run standard tests
+  double tolSvd = 1e-8;  // svd minimum value tolerance
+  double tolMat = 1e-6;  // tolerance for matrix equality check
+  Eigen::MatrixXd X;  // pinv(A)
+  int seed = 64799;
+  double low = -2.0;  double upp = 2.0;  // bounds on values in the A matrix
+  for (int iTest = 0; iTest < 25; iTest++) {
+    // generate test data
+    seed++;
+    int nCol = sns_ik::data_util::getRngInt(seed + 59010, 3, 9);
+    int nRow = sns_ik::data_util::getRngInt(seed + 73052, 2, (nCol-1));  // TODO: any number of rows
+    // Decide whether to use a full-rank or rank degenerate case
+    bool fullRank = sns_ik::data_util::getRngBool(seed + 51348, 0.85);  // usually full rank
+    if (fullRank) {  // generate and test for a full-rank input
+      Eigen::MatrixXd A = sns_ik::data_util::getRngMatrixXd(seed + 23253, nRow, nCol, low, upp);
+      ASSERT_TRUE(sns_ik::pinv_QR(A, &X, tolSvd));
+      checkPseudoInverse(A, X, tolMat);
+    } else {  // generate an test for a rank-deficient input
+      int nRank = std::min(nRow, nCol) - 1;
+      Eigen::MatrixXd A = sns_ik::data_util::getRngMatrixXdRanked(seed + 19669, nRow, nCol, nRank);
+      ASSERT_FALSE(sns_ik::pinv_QR(A, &X, tolSvd));
+    }
+  }
+}
+
+/*************************************************************************************************/
+
+/*
+ * Unit test for pinv_QR_Z()
+ */
+TEST(sns_ik_math_utils, pinv_QR_Z_test)
+{
+  // Run standard tests
+  double tolSvd = 1e-6;  // svd minimum value tolerance
+  double tolMat = 1e-5;  // tolerance for matrix equality check
+  double lambda = 1e-6;  // damping parameter for damped pseudoinverse
+  Eigen::MatrixXd Jstar, Za1;  // outputs of pinv_QR_Z()
+  int seed = 98606;
+  double low = -2.0;  double upp = 2.0;  // bounds on values in the A and P matrix
+  Eigen::MatrixXd A;
+  for (int iTest = 0; iTest < 25; iTest++) {
+    // generate test data
+    int nJoint = sns_ik::data_util::getRngInt(seed + 98138, 4, 12);
+    int nTask = sns_ik::data_util::getRngInt(seed + 90906, 2, nJoint);
+    bool fullRank = sns_ik::data_util::getRngBool(seed + 51348, 0.85);  // usually full rank
+    Eigen::MatrixXd J1;
+    Eigen::MatrixXd Za0 = sns_ik::data_util::getRngMatrixXd(seed + 10218, nJoint, nJoint, low, upp);
+    if (fullRank) {  // generate and test for a full-rank input
+      J1 = sns_ik::data_util::getRngMatrixXd(seed + 65903, nTask, nJoint, low, upp);
+      ASSERT_TRUE(sns_ik::pinv_QR_Z(J1, Za0, &Jstar, &Za1, lambda, tolSvd));
+    } else {  // test the rank-deficient case
+      int nRank = sns_ik::data_util::getRngInt(seed + 82189, 1, nTask-1);
+      Eigen::MatrixXd J1 = sns_ik::data_util::getRngMatrixXdRanked(seed + 48185, nTask, nJoint, nRank);
+      ASSERT_FALSE(sns_ik::pinv_QR_Z(J1, Za0, &Jstar, &Za1, lambda, tolSvd));
+    }
+    // generate matricies for checking the result
+    Eigen::MatrixXd A = (J1 * Za0).transpose();
+    Eigen::MatrixXd Ya1, Z1, Ra1;  // QR decomposition block matricies
+    qrBlockDecompose(A, &Ya1, &Z1, &Ra1);  // perform QR decomposition (for checking result only)
+    // checks:
+    checkEqualMatricies(Za1, Za0 * Z1, tolMat);
+    checkEqualMatricies(Jstar * (Ra1.transpose()), Za0 * Ya1, tolMat);
+  }
+}
+
+/*************************************************************************************************/
+
+// Unit test for isIdentity()
+TEST(sns_ik_math_utils, isIdentity_test)
+{
+  Eigen::MatrixXd M = Eigen::MatrixXd::Identity(3, 3);
+  ASSERT_TRUE(sns_ik::isIdentity(M));
+  M(1,1) = 0.3;
+  ASSERT_FALSE(sns_ik::isIdentity(M));
+}
+
+/*************************************************************************************************/
+
+// Run all the tests that were declared with TEST()
+int main(int argc, char **argv){
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
This commit adds unit tests for each function in the SNS-IK
math utilities (sns_ik_math_util). The main purpose of this
commit is to provide regression tests for future development
and to improve the documentation.

Changes:
- remove pinv_damped(), which was unused and had a bug
- add documentation for all functions in sns_ik_math_util
- add sns_ik_data_utilities, which generate repeatable test data
- add unit test for sns_ik_math_util
- add unit test for sns_ik_data_util

Issues: #71