### PR TITLE
Implemented SnsLinearSolver class and unit tests

### DIFF
--- a/sns_ik_lib/CMakeLists.txt
+++ b/sns_ik_lib/CMakeLists.txt
@@ -35,7 +35,8 @@ link_directories(${orocos_kdl_LIBRARY_DIRS})
 
 # library for private utilities
 add_library(sns_ik_util
-            utilities/sns_ik_math_utils.cpp)
+            utilities/sns_ik_math_utils.cpp
+            utilities/sns_linear_solver.cpp)
 
 # library for public API
 add_library(sns_ik

--- a/sns_ik_lib/test/sns_ik_math_utils_test.cpp
+++ b/sns_ik_lib/test/sns_ik_math_utils_test.cpp
@@ -30,12 +30,12 @@
  *************************************************************************************************/
 
 /*
- * Element-wise check that two matricies are equal to within some tolerance
+ * Element-wise check that two matrices are equal to within some tolerance
  * @param A: first input matrix
  * @param B: second input matrix
  * @param tol: tolerance on equality checks
  */
-void checkEqualMatricies(const Eigen::MatrixXd& A, const Eigen::MatrixXd& B, double tol)
+void checkEqualMatrices(const Eigen::MatrixXd& A, const Eigen::MatrixXd& B, double tol)
 {
   ASSERT_EQ(A.rows(), B.rows());
   ASSERT_EQ(A.cols(), B.cols());
@@ -51,7 +51,7 @@ void checkEqualMatricies(const Eigen::MatrixXd& A, const Eigen::MatrixXd& B, dou
 /*************************************************************************************************/
 
 /*
- * Check that two matricies are related by a Moore-Penrose pseudoinverse, to within tol.
+ * Check that two matrices are related by a Moore-Penrose pseudoinverse, to within tol.
  * X = pinv(A)
  * @param A: matrix A
  * @param X: the pseudoinverse of matrix A
@@ -59,12 +59,12 @@ void checkEqualMatricies(const Eigen::MatrixXd& A, const Eigen::MatrixXd& B, dou
  */
 void checkPseudoInverse(const Eigen::MatrixXd& A, const Eigen::MatrixXd& X, double tol)
 {
-  checkEqualMatricies(A*X*A, A, tol);
-  checkEqualMatricies(X*A*X, X, tol);
+  checkEqualMatrices(A*X*A, A, tol);
+  checkEqualMatrices(X*A*X, X, tol);
   Eigen::MatrixXd XA = X*A;
   Eigen::MatrixXd AX = A*X;
-  checkEqualMatricies(XA, XA.transpose(), tol);
-  checkEqualMatricies(AX, AX.transpose(), tol);
+  checkEqualMatrices(XA, XA.transpose(), tol);
+  checkEqualMatrices(AX, AX.transpose(), tol);
 }
 
 /*************************************************************************************************/
@@ -115,7 +115,7 @@ void checkLinearSolve(const Eigen::MatrixXd& A, const Eigen::MatrixXd& b,
   int m = A.cols();
   ASSERT_LE(rank, std::min(n, m));  // upper bound of rank is based on matrix size
   if (m >= n && rank == std::min(n, m)) {  // there is a feasible solution
-    checkEqualMatricies(A*x, b, tol);
+    checkEqualMatrices(A*x, b, tol);
   }  //  else: the solution is infeasible, x should minimize the norm
 }
 
@@ -125,7 +125,7 @@ void checkLinearSolve(const Eigen::MatrixXd& A, const Eigen::MatrixXd& b,
 
 /*
  * Unit test for the method sns_ik::pinv()
- * TODO: pass arbitrary size matricies into pinv() once the code is fixed to support it
+ * TODO: pass arbitrary size matrices into pinv() once the code is fixed to support it
  */
 TEST(sns_ik_math_utils, pinv_test)
 {
@@ -158,7 +158,7 @@ TEST(sns_ik_math_utils, pinv_test)
 
 /*
  * Unit test for pinv_P()
- * TODO: pass arbitrary size matricies into pinv() once the code is fixed to support it
+ * TODO: pass arbitrary size matrices into pinv() once the code is fixed to support it
  */
 TEST(sns_ik_math_utils, pinv_P_test)
 {
@@ -182,7 +182,7 @@ TEST(sns_ik_math_utils, pinv_P_test)
       A = sns_ik::rng_util::getRngMatrixXd(seed + 75011, nRow, nCol, low, upp);
       ASSERT_TRUE(sns_ik::pinv_P(A, &X, &PP, tolSvd));
       checkPseudoInverse(A, X, tolMat);
-      checkEqualMatricies(PP, P - X*A, tolMat);
+      checkEqualMatrices(PP, P - X*A, tolMat);
     } else {  // generate an test for a rank-deficient input
       int nRank = std::min(nRow, nCol) - 1;
       A = sns_ik::rng_util::getRngMatrixXdRanked(seed + 91579, nRow, nCol, nRank);
@@ -195,7 +195,7 @@ TEST(sns_ik_math_utils, pinv_P_test)
 
 /*
  * Unit test for pinv_damped_P()
- * TODO: pass arbitrary size matricies into pinv_damped_P() once the code is fixed to support it
+ * TODO: pass arbitrary size matrices into pinv_damped_P() once the code is fixed to support it
  */
 TEST(sns_ik_math_utils, pinv_damped_P_test)
 {
@@ -224,7 +224,7 @@ TEST(sns_ik_math_utils, pinv_damped_P_test)
       A = sns_ik::rng_util::getRngMatrixXdRanked(seed + 88433, nRow, nCol, nRank);
       ASSERT_FALSE(sns_ik::pinv_damped_P(A, &X, &PP, lambda, tolSvd));
     }
-    checkEqualMatricies(PP, P - X*A, tolMat);
+    checkEqualMatrices(PP, P - X*A, tolMat);
   }
 }
 
@@ -271,7 +271,7 @@ TEST(sns_ik_math_utils, pinv_forBarP_test)
       // Call the function to be tested:
       ASSERT_TRUE(sns_ik::pinv_forBarP(W, P, &C));
       // Check that the result is valid:
-      checkEqualMatricies(Eigen::MatrixXd::Identity(nnz, nnz), K*C*(K.transpose()), tolMat);
+      checkEqualMatrices(Eigen::MatrixXd::Identity(nnz, nnz), K*C*(K.transpose()), tolMat);
 
     } else { // use the rank-deficient case
         int nRank = 1;
@@ -280,7 +280,7 @@ TEST(sns_ik_math_utils, pinv_forBarP_test)
         // Call the function to be tested:
         ASSERT_FALSE(sns_ik::pinv_forBarP(W, P, &C));
         // Check that the result is valid:
-        checkEqualMatricies(Eigen::MatrixXd::Zero(nDim, nDim), C, tolMat);
+        checkEqualMatrices(Eigen::MatrixXd::Zero(nDim, nDim), C, tolMat);
     }
   }
 }
@@ -289,7 +289,7 @@ TEST(sns_ik_math_utils, pinv_forBarP_test)
 
 /*
  * Unit test for the method sns_ik::pinv_QR()
- * TODO: pass arbitrary size matricies into pinv_QR() once the code is fixed to support it
+ * TODO: pass arbitrary size matrices into pinv_QR() once the code is fixed to support it
  */
 TEST(sns_ik_math_utils, pinv_QR_test)
 {
@@ -348,13 +348,13 @@ TEST(sns_ik_math_utils, pinv_QR_Z_test)
       Eigen::MatrixXd J1 = sns_ik::rng_util::getRngMatrixXdRanked(seed + 48185, nTask, nJoint, nRank);
       ASSERT_FALSE(sns_ik::pinv_QR_Z(J1, Za0, &Jstar, &Za1, lambda, tolSvd));
     }
-    // generate matricies for checking the result
+    // generate matrices for checking the result
     Eigen::MatrixXd A = (J1 * Za0).transpose();
-    Eigen::MatrixXd Ya1, Z1, Ra1;  // QR decomposition block matricies
+    Eigen::MatrixXd Ya1, Z1, Ra1;  // QR decomposition block matrices
     qrBlockDecompose(A, &Ya1, &Z1, &Ra1);  // perform QR decomposition (for checking result only)
     // checks:
-    checkEqualMatricies(Za1, Za0 * Z1, tolMat);
-    checkEqualMatricies(Jstar * (Ra1.transpose()), Za0 * Ya1, tolMat);
+    checkEqualMatrices(Za1, Za0 * Z1, tolMat);
+    checkEqualMatrices(Jstar * (Ra1.transpose()), Za0 * Ya1, tolMat);
   }
 }
 
@@ -401,7 +401,7 @@ TEST(sns_ik_math_utils, pseudoInverse_fullRank_test)
     checkPseudoInverse(A, invA, tolMat);
     ASSERT_FALSE(damped);
     ASSERT_EQ(rank, nRow);
-    checkEqualMatricies(X, invA, tolMat);
+    checkEqualMatrices(X, invA, tolMat);
   }
 }
 
@@ -436,7 +436,7 @@ TEST(sns_ik_math_utils, pseudoInverse_damped_test)
     checkPseudoInverse(A, invA, tolMat);
     ASSERT_TRUE(damped);
     ASSERT_EQ(rank, nRank);
-    checkEqualMatricies(X, invA, tolMat);
+    checkEqualMatrices(X, invA, tolMat);
   }
 }
 
@@ -457,7 +457,7 @@ TEST(sns_ik_math_utils, solveLinearSystem_fullRank_test)
   double err;  // residual error in the solution
   for (int iTest = 0; iTest < nTest; iTest++) {
     int n = sns_ik::rng_util::getRngInt(s1, 3, 9);
-    int m = sns_ik::rng_util::getRngInt(0, n, n + 5);
+    int m = sns_ik::rng_util::getRngInt(0, 3, 9);
     int p = sns_ik::rng_util::getRngInt(0, 1, 3);
     A = sns_ik::rng_util::getRngMatrixXd(s2, n, m, low, upp);
     b = sns_ik::rng_util::getRngMatrixXd(s2, n, p, low, upp);

--- a/sns_ik_lib/test/sns_ik_math_utils_test.cpp
+++ b/sns_ik_lib/test/sns_ik_math_utils_test.cpp
@@ -96,11 +96,11 @@ void qrBlockDecompose(const Eigen::MatrixXd& A,
  * @param b: matrix of size [n, p]
  * @param x: matrix of size [m, p]
  * @param rank: rank of the A
- * @param res: residual error in solution: (A*x-b).squaredNorm()
+ * @param err: residual error in solution: (A*x-b).squaredNorm()
  * @param tol: tolerance for equality checks
  */
 void checkLinearSolve(const Eigen::MatrixXd& A, const Eigen::MatrixXd& b,
-                     const Eigen::MatrixXd& x, int rank, double res, double tol)
+                     const Eigen::MatrixXd& x, int rank, double err, double tol)
 {
   // check sizes:
   ASSERT_EQ(A.cols(), x.rows());
@@ -108,7 +108,7 @@ void checkLinearSolve(const Eigen::MatrixXd& A, const Eigen::MatrixXd& b,
   ASSERT_EQ(x.cols(), b.cols());
 
   // Check residual:
-  ASSERT_NEAR(res, (A*x-b).squaredNorm(), tol);
+  ASSERT_NEAR(err, (A*x-b).squaredNorm(), tol);
 
   // Check linear solve:
   int n = A.rows();
@@ -454,15 +454,15 @@ TEST(sns_ik_math_utils, solveLinearSystem_fullRank_test)
   Eigen::MatrixXd A, b;  // test linear system
   Eigen::MatrixXd x;  // result
   int rank; // rank of A, computed by linear solver
-  double res;  // residual error in the solution
+  double err;  // residual error in the solution
   for (int iTest = 0; iTest < nTest; iTest++) {
     int n = sns_ik::rng_util::getRngInt(s1, 3, 9);
     int m = sns_ik::rng_util::getRngInt(0, n, n + 5);
     int p = sns_ik::rng_util::getRngInt(0, 1, 3);
     A = sns_ik::rng_util::getRngMatrixXd(s2, n, m, low, upp);
     b = sns_ik::rng_util::getRngMatrixXd(s2, n, p, low, upp);
-    ASSERT_TRUE(sns_ik::solveLinearSystem(A, b, &x, &rank, &res));
-    checkLinearSolve(A, b, x, rank, res, tol);
+    ASSERT_TRUE(sns_ik::solveLinearSystem(A, b, &x, &rank, &err));
+    checkLinearSolve(A, b, x, rank, err, tol);
     s1 = s2 = 0; // let the RNG automatically increment after the first iteration
   }
 }
@@ -481,7 +481,7 @@ TEST(sns_ik_math_utils, solveLinearSystem_rankDeficient_test)
   Eigen::MatrixXd A, b;  // test linear system
   Eigen::MatrixXd x;  // result
   int rank; // rank of A, computed by linear solver
-  double res;  // residual error in the solution
+  double err;  // residual error in the solution
   for (int iTest = 0; iTest < nTest; iTest++) {
     int n = sns_ik::rng_util::getRngInt(s1, 4, 9);  // number of equations
     int m = sns_ik::rng_util::getRngInt(0, 4, 9); // number of decision variables
@@ -489,9 +489,9 @@ TEST(sns_ik_math_utils, solveLinearSystem_rankDeficient_test)
     int r = sns_ik::rng_util::getRngInt(0, 1, std::min(n, m));  // rank
     A = sns_ik::rng_util::getRngMatrixXdRanked(s2, n, m, r);
     b = sns_ik::rng_util::getRngMatrixXd(s2, n, p, low, upp);
-    ASSERT_TRUE(sns_ik::solveLinearSystem(A, b, &x, &rank, &res));
+    ASSERT_TRUE(sns_ik::solveLinearSystem(A, b, &x, &rank, &err));
     ASSERT_EQ(r, rank);  // check the rank
-    checkLinearSolve(A, b, x, rank, res, tol);
+    checkLinearSolve(A, b, x, rank, err, tol);
     s1 = s2 = 0; // let the RNG automatically increment after the first iteration
   }
 }

--- a/sns_ik_lib/utilities/sns_ik_math_utils.cpp
+++ b/sns_ik_lib/utilities/sns_ik_math_utils.cpp
@@ -24,6 +24,7 @@
 #include <limits>
 
 #include "sns_ik_math_utils.hpp"
+#include "sns_linear_solver.hpp"
 
 namespace {
   const double EPSQ = 1e-10;
@@ -169,7 +170,7 @@ bool pinv_QR_Z(const Eigen::MatrixXd &A, const Eigen::MatrixXd &Z0, Eigen::Matri
     Eigen::MatrixXd R = Eigen::MatrixXd::Zero(m, m);
     //take the useful part of R
     for (int i = 0; i < m; i++) {
-      for (int j = i; j < m; j++)  // TODO: is starting at i correct?
+      for (int j = i; j < m; j++)
         R(i, j) = hR(i, j);
     }
 
@@ -279,6 +280,46 @@ bool pseudoInverse(const Eigen::MatrixXd& A, double eps, Eigen::MatrixXd* invA,
   // Optional outputs:
   if (rank) { *rank = rankA; }
   if (damped) { *damped = !fullRank; }
+  return true;
+}
+
+/*************************************************************************************************/
+
+bool solveLinearSystem(const Eigen::MatrixXd& A, const Eigen::MatrixXd& b,
+                       Eigen::MatrixXd* x, int* rank, double* res)
+{
+  // Input validation:
+  if (A.rows() != b.rows()) {
+    ROS_ERROR("Bad Input:  A.rows(%d) != b.rows(%d)", int(A.rows()), int(b.rows()));
+    return false;
+  }
+  if (!x) { ROS_ERROR("x is nullptr!"); return false; }
+
+  // Decompose the matrix A and then check the it worked
+  int n = A.rows();
+  int m = A.cols();
+  SnsLinearSolver solver(n, m);
+  solver.setThreshold(Eigen::Default); // Eigen does something reasonable here
+  solver.compute(A);  // perform matrix decomposition
+  if(solver.info() != Eigen::ComputationInfo::Success) {
+    ROS_ERROR("Solver failed to decompose the combined sparse matrix!");
+    return false;
+  }
+
+  // Solve the linear system and then check that it worked
+  *x = solver.solve(b);
+  if (solver.info() != Eigen::ComputationInfo::Success) {
+    ROS_ERROR("Solver failed to find a valid solution!");
+    return false;
+  }
+
+  // Optional outputs:
+  if (rank) {  // then compute the number of degrees of freedom in the solution
+    *rank = solver.rank();
+  }
+  if (res) {  // then compute the residual error in the solution
+    *res = (A*(*x) - b).squaredNorm();
+  }
   return true;
 }
 

--- a/sns_ik_lib/utilities/sns_ik_math_utils.cpp
+++ b/sns_ik_lib/utilities/sns_ik_math_utils.cpp
@@ -286,7 +286,7 @@ bool pseudoInverse(const Eigen::MatrixXd& A, double eps, Eigen::MatrixXd* invA,
 /*************************************************************************************************/
 
 bool solveLinearSystem(const Eigen::MatrixXd& A, const Eigen::MatrixXd& b,
-                       Eigen::MatrixXd* x, int* rank, double* res)
+                       Eigen::MatrixXd* x, int* rank, double* err)
 {
   // Input validation:
   if (A.rows() != b.rows()) {
@@ -317,8 +317,8 @@ bool solveLinearSystem(const Eigen::MatrixXd& A, const Eigen::MatrixXd& b,
   if (rank) {  // then compute the number of degrees of freedom in the solution
     *rank = solver.rank();
   }
-  if (res) {  // then compute the residual error in the solution
-    *res = (A*(*x) - b).squaredNorm();
+  if (err) {  // then compute the residual error in the solution
+    *err = (A*(*x) - b).squaredNorm();
   }
   return true;
 }

--- a/sns_ik_lib/utilities/sns_ik_math_utils.hpp
+++ b/sns_ik_lib/utilities/sns_ik_math_utils.hpp
@@ -170,6 +170,19 @@ bool isIdentity(const Eigen::MatrixXd &A);
 bool pseudoInverse(const Eigen::MatrixXd& A, double eps, Eigen::MatrixXd* invA,
                    int* rank = nullptr, bool* damped = nullptr);
 
+/*
+ * Compute the solution to the linear system: A*x = b
+ * @param A: matrix of size [n, m]
+ * @param b: matrix of size [n, p]
+ * @param[out] x: matrix of size [m, p]
+ * @param[out, opt] rank: rank of the A
+ * @param[out, opt] res: residual error in solution: (A*x-b).squaredNorm()
+ * @return: true iff successful
+ */
+bool solveLinearSystem(const Eigen::MatrixXd& A, const Eigen::MatrixXd& b,
+                       Eigen::MatrixXd* x,
+                       int* rank = nullptr, double* res = nullptr);
+
 }  // namespace sns_ik
 
 #endif

--- a/sns_ik_lib/utilities/sns_ik_math_utils.hpp
+++ b/sns_ik_lib/utilities/sns_ik_math_utils.hpp
@@ -176,12 +176,12 @@ bool pseudoInverse(const Eigen::MatrixXd& A, double eps, Eigen::MatrixXd* invA,
  * @param b: matrix of size [n, p]
  * @param[out] x: matrix of size [m, p]
  * @param[out, opt] rank: rank of the A
- * @param[out, opt] res: residual error in solution: (A*x-b).squaredNorm()
+ * @param[out, opt] err: residual error in solution: (A*x-b).squaredNorm()
  * @return: true iff successful
  */
 bool solveLinearSystem(const Eigen::MatrixXd& A, const Eigen::MatrixXd& b,
                        Eigen::MatrixXd* x,
-                       int* rank = nullptr, double* res = nullptr);
+                       int* rank = nullptr, double* err = nullptr);
 
 }  // namespace sns_ik
 

--- a/sns_ik_lib/utilities/sns_linear_solver.cpp
+++ b/sns_ik_lib/utilities/sns_linear_solver.cpp
@@ -2,11 +2,9 @@
  *
  * @brief Linear Solver, used by the SNS-IK velocity IK solvers.
  * @author: Matthew Kelly
- *
- * This class is used to solve linear systems. It is a wrapper for two different internal solvers:
- *   --> psuedo-inverse solver: included for legacy support on Eigen 3.2.0
- *   --> direct linear solver: prefered solver when available. Requries Eigen 3.3.4
- *
+ */
+
+/**
  *    Copyright 2018 Rethink Robotics
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,6 +17,13 @@
  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
+ */
+
+/*
+ *
+ * This class is used to solve linear systems. It is a wrapper for two different internal solvers:
+ *   --> psuedo-inverse solver: included for legacy support on Eigen 3.2.0
+ *   --> direct linear solver: prefered solver when available. Requries Eigen 3.3.4
  */
 
 #include "sns_linear_solver.hpp"

--- a/sns_ik_lib/utilities/sns_linear_solver.cpp
+++ b/sns_ik_lib/utilities/sns_linear_solver.cpp
@@ -1,0 +1,85 @@
+/** @file sns_linear_solver.cpp
+ *
+ * @brief Linear Solver, used by the SNS-IK velocity IK solvers.
+ * @author: Matthew Kelly
+ *
+ * This class is used to solve linear systems. It is a wrapper for two different internal solvers:
+ *   --> psuedo-inverse solver: included for legacy support on Eigen 3.2.0
+ *   --> direct linear solver: prefered solver when available. Requries Eigen 3.3.4
+ *
+ *    Copyright 2018 Rethink Robotics
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "sns_linear_solver.hpp"
+
+#if EIGEN_VERSION_AT_LEAST(3,3,4)  //  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - //
+// Eigen version is newer than 3.3.4: CompleteOrthogonalDecomposition is defined
+// We're done - just use the implementation from Eigen
+
+#else  // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - //
+// Eigen version is older than 3.3.4: CompleteOrthogonalDecomposition is not defined
+// Implement much of the API for CompleteOrthogonalDecomposition, but use the same back-end as
+// the original implementation of the SNS-IK solver.
+// https://eigen.tuxfamily.org/dox/classEigen_1_1CompleteOrthogonalDecomposition.html
+
+#include "sns_ik_math_utils.hpp"
+#include <ros/console.h>
+
+namespace sns_ik {
+
+static const double DEFAULT_THRESHOLD = 1e-8;
+
+SnsLinearSolver::SnsLinearSolver()
+  : info_(Eigen::Success), rank_(0)
+{
+  setThreshold(Eigen::Default);
+}
+
+SnsLinearSolver::SnsLinearSolver(int n, int m)
+  : info_(Eigen::Success), A_(n, m), invA_(m, n), rank_(0)
+{
+  setThreshold(Eigen::Default);
+}
+
+SnsLinearSolver::SnsLinearSolver(const Eigen::MatrixXd& A)
+  : SnsLinearSolver(A.rows(), A.cols())
+{
+  setThreshold(Eigen::Default); compute(A);
+}
+
+Eigen::MatrixXd SnsLinearSolver::solve(const Eigen::MatrixXd& b)
+{
+  static bool PRINT_WARNING = true;
+  if (PRINT_WARNING) {
+    ROS_WARN("Using legacy code. Upgrade to at least Eigen 3.3.4 for improved linear solver.");
+    PRINT_WARNING = false;  // only print the warning once.
+  }
+  return invA_ * b;
+}
+
+void SnsLinearSolver::compute(const Eigen::MatrixXd& A)
+{
+  A_ = A;
+  if (!sns_ik::pseudoInverse(A_, tol_, &invA_, &rank_)) {
+    info_ = Eigen::InvalidInput;
+  }
+}
+
+void SnsLinearSolver::setThreshold(Eigen::Default_t tol) {
+  setThreshold(DEFAULT_THRESHOLD);
+}
+
+}  // namespace sns_ik
+
+#endif  // EIGEN_VERSION_AT_LEAST(3,3,4)  //- - - - - - - - - - - - - - - - - - - - - - - - - - //

--- a/sns_ik_lib/utilities/sns_linear_solver.hpp
+++ b/sns_ik_lib/utilities/sns_linear_solver.hpp
@@ -1,0 +1,113 @@
+/** @file sns_linear_solver.hpp
+ *
+ * @brief Linear Solver, used by the SNS-IK velocity IK solvers.
+ * @author: Matthew Kelly
+ *
+ * This class is used to solve linear systems. It is a wrapper for two different internal solvers:
+ *   --> psuedo-inverse solver: included for legacy support on Eigen 3.2.0
+ *   --> direct linear solver: prefered solver when available. Requries Eigen 3.3.4
+ *
+ *    Copyright 2018 Rethink Robotics
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <Eigen/Dense>
+
+namespace sns_ik {
+
+#if EIGEN_VERSION_AT_LEAST(3,3,4)  //  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - //
+// Eigen version is newer than 3.3.4: CompleteOrthogonalDecomposition is defined
+typedef Eigen::CompleteOrthogonalDecomposition<Eigen::MatrixXd> SnsLinearSolver;
+
+#else  // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - //
+// Eigen version is older than 3.3.4: CompleteOrthogonalDecomposition is not defined
+// Implement much of the API for CompleteOrthogonalDecomposition, but use the same back-end as
+// the original implementation of the SNS-IK solver.
+// https://eigen.tuxfamily.org/dox/classEigen_1_1CompleteOrthogonalDecomposition.html
+
+class SnsLinearSolver {
+
+public:
+
+  /*
+   * Create a default linear solver
+   */
+  SnsLinearSolver();
+
+  /*
+   * Create a default linear solver with memory preallocation
+   */
+  SnsLinearSolver(int n, int m);
+
+  /*
+   * Create a linear solver for the matrix A*x = b
+   * @param A: matrix of interest
+   */
+  SnsLinearSolver(const Eigen::MatrixXd& A);
+
+  /*
+   * Set and decompose the matrix in the linear system.
+   */
+  void compute(const Eigen::MatrixXd& A);
+
+  /*
+   * Find x to minimize:  ||A*x - b||^2
+   * @param b: right hand side of the linear system
+   * @return: x = solution to the optimization problem
+   */
+  Eigen::MatrixXd solve(const Eigen::MatrixXd& b);
+
+  /*
+   * @return: status of the solver
+   */
+  Eigen::ComputationInfo info() const { return info_; };
+
+  /*
+   * Set the threshold that is used for computing rank and pseudoinverse
+   * @param tol: threshold used for decomposing matrix and computing rank
+   */
+  void setThreshold(Eigen::Default_t tol);
+
+  /*
+   * Set the threshold that is used for computing rank and pseudoinverse
+   * @param tol: threshold used for decomposing matrix and computing rank
+   */
+  void setThreshold(double tol) { tol_ = tol; };
+
+  /*
+   * @return: the rank of the matrix A
+   */
+  int rank() const { return rank_; };
+
+private:
+
+  // status of the most recent solve operation
+  Eigen::ComputationInfo info_;
+
+  // the "A" matrix in A*x = b
+  Eigen::MatrixXd A_;
+
+  // the pseudo-inverse of "A"
+  Eigen::MatrixXd invA_;
+
+  // tolerance that is used for checking for non-trivial singular values
+  double tol_;
+
+  // rank of "A"
+  int rank_;
+
+};
+
+#endif  // EIGEN_VERSION_AT_LEAST(3,3,4)  //- - - - - - - - - - - - - - - - - - - - - - - - - - //
+
+}  // namespace sns_ik

--- a/sns_ik_lib/utilities/sns_linear_solver.hpp
+++ b/sns_ik_lib/utilities/sns_linear_solver.hpp
@@ -2,11 +2,9 @@
  *
  * @brief Linear Solver, used by the SNS-IK velocity IK solvers.
  * @author: Matthew Kelly
- *
- * This class is used to solve linear systems. It is a wrapper for two different internal solvers:
- *   --> psuedo-inverse solver: included for legacy support on Eigen 3.2.0
- *   --> direct linear solver: prefered solver when available. Requries Eigen 3.3.4
- *
+ */
+
+/**
  *    Copyright 2018 Rethink Robotics
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,6 +17,13 @@
  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
+ */
+
+/*
+ *
+ * This class is used to solve linear systems. It is a wrapper for two different internal solvers:
+ *   --> psuedo-inverse solver: included for legacy support on Eigen 3.2.0
+ *   --> direct linear solver: prefered solver when available. Requries Eigen 3.3.4
  */
 
 #include <Eigen/Dense>


### PR DESCRIPTION
This commit adds a new linear solver to the SNS utility library,
which can be used as the back-end solver for most of the methods.
There are two key motivators here:
1) replace the pinv() with a direct linear solve (new eigen only)
2) implement a standard and well-tested solver to use throughout the code

For old versions of Eigen this code defines a class
SnsLinearSolver that implements a nearly identical
API to `Eigen::CompleteOrthogonalDecomposition`.

For new versions of Eigen this file provides typedef of the
`Eigen::CompleteOrthogonalDecomposition` class.

Tested on Both Eigen 3.3.4 and Eigen 3.2.0