### PR TITLE
Kinetic: Adds missing includes and auto for melodic (#90)

### DIFF
--- a/sns_ik_lib/include/sns_ik/sns_vel_ik_base.hpp
+++ b/sns_ik_lib/include/sns_ik/sns_vel_ik_base.hpp
@@ -26,6 +26,7 @@
 
 #include <Eigen/Dense>
 #include <memory>
+#include <vector>
 
 #include "sns_linear_solver.hpp"
 

--- a/sns_ik_lib/include/sns_ik/sns_velocity_ik.hpp
+++ b/sns_ik_lib/include/sns_ik/sns_velocity_ik.hpp
@@ -24,6 +24,7 @@
 #define SNS_IK_VELOCITY_IK
 
 #include <Eigen/Dense>
+#include <vector>
 
 namespace sns_ik {
 

--- a/sns_ik_lib/src/sns_ik.cpp
+++ b/sns_ik_lib/src/sns_ik.cpp
@@ -80,7 +80,6 @@ namespace sns_ik {
     }
 
     std::vector<KDL::Segment> chain_segments = m_chain.segments;
-    boost::shared_ptr<const urdf::Joint> joint;
     m_lower_bounds.resize(m_chain.getNrOfJoints());
     m_upper_bounds.resize(m_chain.getNrOfJoints());
     m_velocity.resize(m_chain.getNrOfJoints());
@@ -89,7 +88,10 @@ namespace sns_ik {
 
     unsigned int joint_num=0;
     for(std::size_t i = 0; i < chain_segments.size(); ++i) {
-      joint = robot_model.getJoint(chain_segments[i].getJoint().getName());
+      // auto joint is of type shared_ptr<const urdf::Joint>
+      // prior to ROS Melodic, this is a boost::shared_ptr
+      // ROS Melodic and later, this is a std::shared_ptr
+      auto joint = robot_model.getJoint(chain_segments[i].getJoint().getName());
       if (joint->type != urdf::Joint::UNKNOWN && joint->type != urdf::Joint::FIXED) {
         double lower=0; //TODO Better default values? Error if these arent found?
         double upper=0;


### PR DESCRIPTION
The gcc compiler in bionic (v7.3.0) is (correctly)
more strict about requiring include files in headers.
This meant we needed to add few additional vector
includes.

Additionally, urdf::Model::getJoint() has switched
from returning a boost::shared_ptr<const urdf::Joint>
to returning std::shared_ptr<const urdf::Joint> in ros
melodic. To be flexible and simultaneously build on
different branches, we're using "auto" to capture the
correct type everywhere.