### PR TITLE
Add acceleration-based SNS IK base solver with unit test

### DIFF
--- a/sns_ik_lib/CMakeLists.txt
+++ b/sns_ik_lib/CMakeLists.txt
@@ -58,7 +58,8 @@ if (CATKIN_ENABLE_TESTING)
   # library for test utilities
   add_library(sns_ik_test
             test/rng_utilities.cpp
-            test/sawyer_model.cpp)
+            test/sawyer_model.cpp
+            test/test_utilities.cpp)
   target_link_libraries(sns_ik_test sns_ik ${catkin_LIBRARIES})
 
   # unit tests

--- a/sns_ik_lib/CMakeLists.txt
+++ b/sns_ik_lib/CMakeLists.txt
@@ -39,6 +39,7 @@ add_library(sns_ik
             src/fsns_velocity_ik.cpp
             src/osns_sm_velocity_ik.cpp
             src/osns_velocity_ik.cpp
+            src/sns_acc_ik_base.cpp
             src/sns_ik.cpp
             src/sns_position_ik.cpp
             src/sns_vel_ik_base.cpp
@@ -71,5 +72,7 @@ if (CATKIN_ENABLE_TESTING)
   target_link_libraries(sns_ik_vel_test sns_ik sns_ik_test ${catkin_LIBRARIES})
   catkin_add_gtest(sns_vel_ik_base_test test/sns_vel_ik_base_test.cpp)
   target_link_libraries(sns_vel_ik_base_test sns_ik sns_ik_test ${catkin_LIBRARIES})
+  catkin_add_gtest(sns_acc_ik_base_test test/sns_acc_ik_base_test.cpp)
+  target_link_libraries(sns_acc_ik_base_test sns_ik sns_ik_test ${catkin_LIBRARIES})
 
 endif()

--- a/sns_ik_lib/include/sns_ik/sns_acc_ik_base.hpp
+++ b/sns_ik_lib/include/sns_ik/sns_acc_ik_base.hpp
@@ -3,6 +3,7 @@
  * @brief The file provides the basic implementation of the SNS-IK acceleration solver
  *
  * @author Matthew Kelly
+ * @author Andy Park
  *
  * This file provides a set of functions that return simple kinematic chains that are used for the
  * unit tests. This allows unit tests to run quickly without depending on external URDF files.

--- a/sns_ik_lib/include/sns_ik/sns_acc_ik_base.hpp
+++ b/sns_ik_lib/include/sns_ik/sns_acc_ik_base.hpp
@@ -1,0 +1,196 @@
+/** @file sns_acc_ik_base.hpp
+ *
+ * @brief The file provides the basic implementation of the SNS-IK acceleration solver
+ *
+ * @author Matthew Kelly
+ *
+ * This file provides a set of functions that return simple kinematic chains that are used for the
+ * unit tests. This allows unit tests to run quickly without depending on external URDF files.
+ *
+ *    Copyright 2018 Rethink Robotics
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#ifndef SNS_IK_LIB__SNS_ACC_IK_H_
+#define SNS_IK_LIB__SNS_ACC_IK_H_
+
+#include <Eigen/Dense>
+#include <memory>
+
+#include "sns_linear_solver.hpp"
+
+namespace sns_ik {
+
+
+class SnsAccIkBase {
+
+public:
+
+  // Smart pointer typedefs. Note: all derived classes MUST override these smart pointers.
+  typedef std::shared_ptr<SnsAccIkBase> Ptr;
+  typedef std::unique_ptr<SnsAccIkBase> uPtr;
+
+  enum class ExitCode {
+    Success,  // successfully solver the optimization problem
+    BadUserInput,  // user input failed basic checks (eg. inconsistent matrix size)
+    InfeasibleTask,  // there is no feasible solution to the primary task
+    InternalError  // there was an internal error in the solver (should never happen...)
+  };
+
+  /**
+   * Create a default solver with nJnt joints and no bounds on joint acceleration
+   * @param nJnt: number of joints in the robot model (columns in the jacobian)
+   * @return: acceleration solver iff successful, nullptr otherwise
+   */
+  static std::unique_ptr<SnsAccIkBase> create(int nJnt);
+
+  /**
+   * Create a default solver with nJnt joints and infinite bounds on the joint acceleration.
+   * @param ddqLow: lower bound on the acceleration of each joint
+   * @param ddqUpp: upper bound on the acceleration of each joint
+   * @return: acceleration solver iff successful, nullptr otherwise
+   */
+  static std::unique_ptr<SnsAccIkBase> create(const Eigen::ArrayXd& ddqLow,
+                                              const Eigen::ArrayXd& ddqUpp);
+
+  // Make sure that class is cleaned-up correctly
+  virtual ~SnsAccIkBase() {};
+
+  /**
+   * Set the bounds on joint acceleration.
+   * Set a bound to infinity (or an arbitrarily large value) to disable it.
+   * This method will update the number of joints in the solver
+   * Requirements: inputs must be the same size and ddqLow < ddqUpp
+   * @param ddqLow: lower bound on the acceleration of each joint
+   * @param ddqUpp: upper bound on the acceleration of each joint
+   * @return: true iff successful
+   */
+  bool setAccBnd(const Eigen::ArrayXd& ddqLow, const Eigen::ArrayXd& ddqUpp);
+
+  /**
+   * Solve a acceleration IK problem with no null-space bias of joint-space optimization.
+   *
+   *  This method implements   "Algorithm 1: SNS algorithm"   from the paper:
+   *  "Prioritized multi-task motion control of redundant robots under hard joint constraints"
+   *   by: Fabrizio Flacco, Alessandro De Luca, Oussama Khatib
+   *
+   * Solve for joint acceleration ddqUpp and task scale s:
+   *
+   *  maximize: s
+   *  subject to:
+   *    s * ddx = J * ddq + dJ*dq
+   *    0 < s <= 1
+   *    ddqLow <= ddqUpp <= ddqUpp      ( bounds set in constructor or setVelBnd() )
+   *
+   * @param J: Jacobian matrix, mapping from joint to task space. Size = [nTask, nJoint]
+   * @param dJdq: the product of Jacobian derivative and joint velocity. Length = nTask
+   * @param dx: task acceleration vector. Length = nTask
+   * @param[out] ddqUpp: joint acceleration solution. Length = nJoint
+   * @param[out] taskScale: task scale.  fwdKin(q, dq, ddq) = taskScale*ddx
+   *                            taskScale == 1.0  --> task was feasible
+   *                            taskScale < 1.0  --> task was infeasible and had to be scaled
+   * @return: Success: the algorithm worked correctly and satisfied the problem statement
+   *          otherwise: something went wrong
+   */
+  ExitCode solve(const Eigen::MatrixXd& J, const Eigen::VectorXd& dJdq, const Eigen::VectorXd& dx,
+                      Eigen::VectorXd* ddqUpp, double* taskScale);
+
+
+protected:
+
+  /*
+   * protected constructor: require factory method to create an object.
+   */
+  SnsAccIkBase(int nJnt) : nJnt_(nJnt), ddqLow_(nJnt), ddqUpp_(nJnt) {};
+
+  /*
+   * Check that ddqLow_ <= ddqUpp <= ddqUpp_
+   * @param ddqUpp: joint acceleration to test
+   * @return: true iff ddqLow <= ddq <= ddqUpp
+   *          if ddqUpp.empty() return false
+   */
+  bool checkAccBnd(const Eigen::VectorXd& ddq);
+
+  /*
+   * Solve the following equation for the variable ddqUpp:
+   *    J * W * (ddq - dqNull) = ddx - dJdq - J*ddqNull
+   * This equation appears throughout the SNS-IK papers. One example is in block "D" of Algorithm 1:
+   *  "Control of Redundant Robots Under Hard Joint Constraint: Saturation in the Null Space"
+   *   by: Fabrizio Flacco, Alessandro De Luca, Oussama Khatib
+   *
+   * PRECONDITION:
+   * --> Assumes that linSolver_ has been initialized with J*W
+   *
+   * @param J: Jacobian matrix, mapping from joint to task space. Size = [nTask, nJoint]
+   * @param dJdq: the product of Jacobian derivative and joint velocity. Length = nTask
+   * @param JW: J*W = Jacobian projected onto the active joints. Size = [nTask, nJoint]
+   * @param ddqNull: null-space joint acceleration. Size = nJoint
+   * @param ddx: task acceleration vector. Length = nTask
+   * @param[out] ddq: joint acceleration solution. Length = nJoint
+   * @param[out, opt] resErr: residual error (norm-squared)
+   * @return: true --> success!
+   *          false --> invalid input or other error
+   */
+  bool solveProjectionEquation(const Eigen::MatrixXd& J, const Eigen::VectorXd& dJdq,
+                               const Eigen::MatrixXd& JW, const Eigen::VectorXd& dqNull,
+                               const Eigen::VectorXd& ddx, Eigen::VectorXd* ddq, double* resErr);
+
+  /*
+   * This method implements Algorithm 2 (and a bit of Algorithm 1) from the paper:
+   *  "Control of Redundant Robots Under Hard Joint Constraint: Saturation in the Null Space"
+   *   by: Fabrizio Flacco, Alessandro De Luca, Oussama Khatib
+   *
+   * PRECONDITION:
+   * --> Assumes that linSolver_ has been initialized with J*W
+   *
+   * @param J: Jacobian matrix, mapping from joint to task space. Size = [nTask, nJoint]
+   * @param dJdq: the product of Jacobian derivative and joint velocity. Length = nTask
+   * @param JW: J*W = Jacobian projected onto the active joints. Size = [nTask, nJoint]
+   * @param ddx: task acceleration vector. Length = nTask
+   * @param ddqUpp: joint acceleration. Length = nJoint
+   * @param ddqUpp: joint acceleration. Length = nJoint
+   * @param jntIsFree: which joints are free to saturate? Length = nJoint
+   * @param[out] taskScale: task scale factor
+   * @param[out] jntIdx: index corresponding to the most critical joint that is free
+   * @param[out] resErr: residual error (norm-squared) in the linear solve
+   * @return: true --> success!
+   *          false --> invalid input or other error
+   */
+  ExitCode computeTaskScalingFactor(const Eigen::MatrixXd& J, const Eigen::MatrixXd& JW, const Eigen::VectorXd& ddx,
+                                              const Eigen::VectorXd& ddq, const std::vector<bool>& jntIsFree,
+                                              double* taskScale, int* jntIdx, double* resErr);
+
+   /*
+    * This algorithm computes the scale factor that is associated with a given joint, but considering
+    * both the sensativity of the joint (a) and the distance to the upper and lower limits.
+    * @param low: lower margin
+    * @param upp: upper margin
+    * @param a: margin scale factor
+    * @return: joint scale factor
+    */
+   static double findScaleFactor(double low, double upp, double a);
+
+private:
+
+  int nJnt_; //!< number of joints
+
+  Eigen::ArrayXd ddqLow_;  //!< lower bound on joint acceleration
+  Eigen::ArrayXd ddqUpp_;  //!< upper bound on joint acceleration
+
+  SnsLinearSolver linSolver_;  //!< linear solver for the core SNS-IK algorithm
+
+};  // class SnsAccIkBase
+
+}  // namespace sns_ik
+
+#endif  // SNS_IK_LIB__SNS_ACC_IK_H_

--- a/sns_ik_lib/include/sns_ik/sns_vel_ik_base.hpp
+++ b/sns_ik_lib/include/sns_ik/sns_vel_ik_base.hpp
@@ -3,6 +3,7 @@
  * @brief The file provides the basic implementation of the SNS-IK velocity solver
  *
  * @author Matthew Kelly
+ * @author Andy Park
  *
  * This file provides a set of functions that return simple kinematic chains that are used for the
  * unit tests. This allows unit tests to run quickly without depending on external URDF files.

--- a/sns_ik_lib/src/sns_acc_ik_base.cpp
+++ b/sns_ik_lib/src/sns_acc_ik_base.cpp
@@ -1,8 +1,9 @@
-/** @file sns_vel_ik_base.cpp
+/** @file sns_acc_ik_base.cpp
  *
  * @brief The file provides the basic implementation of the SNS-IK acceleration solver
  *
  * @author Matthew Kelly
+ * @author Andy Park
  *
  * This file provides a set of functions that return simple kinematic chains that are used for the
  * unit tests. This allows unit tests to run quickly without depending on external URDF files.
@@ -124,11 +125,11 @@ SnsAccIkBase::ExitCode SnsAccIkBase::solve(const Eigen::MatrixXd& J, const Eigen
   if (!taskScale) { ROS_ERROR("taskScale is nullptr!"); return ExitCode::BadUserInput; }
   int nTask = ddx.size();
   if (nTask <= 0) {
-    ROS_ERROR("Bad Input: dx.size() > 0 is required!");
+    ROS_ERROR("Bad Input: ddx.size() > 0 is required!");
     return ExitCode::BadUserInput;
   }
   if (int(J.rows()) != nTask) {
-    ROS_ERROR("Bad Input: J.rows() == dx.size() is required!");
+    ROS_ERROR("Bad Input: J.rows() == ddx.size() is required!");
     return ExitCode::BadUserInput;
   }
   if (int(J.cols()) != nJnt_) {

--- a/sns_ik_lib/src/sns_acc_ik_base.cpp
+++ b/sns_ik_lib/src/sns_acc_ik_base.cpp
@@ -1,0 +1,408 @@
+/** @file sns_vel_ik_base.cpp
+ *
+ * @brief The file provides the basic implementation of the SNS-IK acceleration solver
+ *
+ * @author Matthew Kelly
+ *
+ * This file provides a set of functions that return simple kinematic chains that are used for the
+ * unit tests. This allows unit tests to run quickly without depending on external URDF files.
+ *
+ *    Copyright 2018 Rethink Robotics
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#include <sns_ik/sns_acc_ik_base.hpp>
+
+#include <ros/console.h>
+#include <limits>
+
+namespace sns_ik {
+
+// Nice formatting for printing eigen arrays.
+static const Eigen::IOFormat EigArrFmt4(4, 0, ", ", "\n", "[", "]");
+
+/*
+ * The code of the SNS-IK solver relies on a linear solver. If the linear system is infeasible,
+ * then the solver will return the minimum-norm solution with a non-zero (positive) residual.
+ * This corresponds to a situation where there is no feasible solution to the task objective, for
+ * example, a one-link robot arm where the task acceleration is along the axis of the joint. This
+ * threshold is used to determine if the task is infeasible.
+ */
+static const double LIN_SOLVE_RESIDUAL_TOL = 1e-8;
+
+/*
+ * If all goes well, then the solver should always terminate the main loop. If something crazy
+ * happens, then we want to prevent an infinite loop. The maximum iteration count is given by
+ * this factor multiplied by the number of joints in the task jacobian.
+ */
+static const int MAXIMUM_SOLVER_ITERATION_FACTOR = 100;
+
+// Short names for useful constants
+static const double POS_INF = std::numeric_limits<double>::max();
+static const double NEG_INF = std::numeric_limits<double>::lowest();
+
+// Any number smaller than this is considered to be zero for numerical purposes
+static const double MINIMUM_FINITE_SCALE_FACTOR = 1e-10;
+
+// Any number larger than this is considered to be infinite for numerical purposes
+static const double MAXIMUM_FINITE_SCALE_FACTOR = 1e10;
+
+// Tolerance for checks on the acceleration limits
+static const double ACCELERATION_BOUND_TOLERANCE = 1e-8;
+
+/*************************************************************************************************
+ *                                 Public Methods                                                *
+ *************************************************************************************************/
+
+SnsAccIkBase::uPtr SnsAccIkBase::create(int nJnt)
+{
+  if (nJnt <= 0) {
+    ROS_ERROR("Bad Input: ddqLow.size(%d) > 0 is required!", nJnt);
+    return nullptr;
+  }
+  Eigen::ArrayXd ddqLow = NEG_INF*Eigen::ArrayXd::Ones(nJnt);
+  Eigen::ArrayXd ddqUpp = POS_INF*Eigen::ArrayXd::Ones(nJnt);
+  return create(ddqLow, ddqUpp);
+}
+
+/*************************************************************************************************/
+
+SnsAccIkBase::uPtr SnsAccIkBase::create(const Eigen::ArrayXd& ddqLow, const Eigen::ArrayXd& ddqUpp)
+{
+  // Input validation
+  int nJnt = ddqLow.size();
+  if (nJnt <= 0) {
+    ROS_ERROR("Bad Input: ddqLow.size(%d) > 0 is required!", nJnt);
+    return nullptr;
+  }
+
+  // Create an empty solver
+  SnsAccIkBase::uPtr accIk(new SnsAccIkBase(nJnt));
+
+  // Set the joint limits:
+  if (!accIk->setAccBnd(ddqLow, ddqUpp)) { ROS_ERROR("Bad Input!"); return nullptr; };
+
+  return accIk;
+}
+
+/*************************************************************************************************/
+
+bool SnsAccIkBase::setAccBnd(const Eigen::ArrayXd& ddqLow, const Eigen::ArrayXd& ddqUpp)
+{
+  int nJnt = ddqLow.size();
+  if (nJnt <= 0) {
+    ROS_ERROR("Bad Input: ddqLow.size(%d) > 0 is required!", nJnt);
+    return false;
+  }
+  if (ddqLow.size() != ddqUpp.size()) {
+    ROS_ERROR("Bad Input: ddqLow.size(%d) == ddqUpp.size(%d) is required!",
+              int(ddqLow.size()), int(ddqUpp.size()));
+    return false;
+  }
+  nJnt_ = nJnt;
+  ddqLow_ = ddqLow;
+  ddqUpp_ = ddqUpp;
+  return true;
+}
+
+/*************************************************************************************************/
+
+SnsAccIkBase::ExitCode SnsAccIkBase::solve(const Eigen::MatrixXd& J, const Eigen::VectorXd& dJdq,
+                                           const Eigen::VectorXd& ddx, Eigen::VectorXd* ddq, double* taskScale)
+{
+  // Input validation
+  if (!ddq) { ROS_ERROR("ddq is nullptr!"); return ExitCode::BadUserInput; }
+  if (!taskScale) { ROS_ERROR("taskScale is nullptr!"); return ExitCode::BadUserInput; }
+  int nTask = ddx.size();
+  if (nTask <= 0) {
+    ROS_ERROR("Bad Input: dx.size() > 0 is required!");
+    return ExitCode::BadUserInput;
+  }
+  if (int(J.rows()) != nTask) {
+    ROS_ERROR("Bad Input: J.rows() == dx.size() is required!");
+    return ExitCode::BadUserInput;
+  }
+  if (int(J.cols()) != nJnt_) {
+    ROS_ERROR("Bad Input: J.cols() == nJnt is required!");
+    return ExitCode::BadUserInput;
+  }
+  int dJdqDim = dJdq.size();
+  if (dJdqDim != nTask) {
+    ROS_ERROR("Bad Input: dJdq.size() == nTask is required!");
+    return ExitCode::BadUserInput;
+  }
+
+  // Local variable initialization:
+  Eigen::MatrixXd W = Eigen::MatrixXd::Identity(nJnt_, nJnt_);  // null-space selection matrix
+  Eigen::VectorXd ddqNull = Eigen::VectorXd::Zero(nJnt_);  // acceleration in the null-space
+  *taskScale = 1.0;  // task scale (assume feasible solution until proven otherwise)
+
+  // Temp. variables to store the best solution
+  double bestTaskScale = 0.0;  // temp variable to track the lower bound on the task scale between iterations
+  Eigen::MatrixXd bestW;  // temp variable to track W before it has been accepted
+  Eigen::VectorXd bestDdqNull;  // temp variable to track dqNull between iterations
+
+  // TODO: see if this can be moved into the main loop, rather than calling here and again at the end
+  // Set the linear solver for this iteration:
+  Eigen::MatrixXd JW = J*W;
+  linSolver_ = SnsLinearSolver(JW);
+  if(linSolver_.info() != Eigen::ComputationInfo::Success) {
+    ROS_ERROR("Solver failed to decompose the combined sparse matrix!");
+    return ExitCode::InternalError;
+  }
+
+  // Keep track of which joints are saturated:
+  std::vector<bool> jointIsFree(nJnt_, true);
+
+  // Main solver loop:
+  double resErr;  // residual error in the linear solver
+  for (int iter = 0; iter < nJnt_ * MAXIMUM_SOLVER_ITERATION_FACTOR; iter++) {
+
+    // Compute the joint acceleration given current saturation set:
+    if (!solveProjectionEquation(J, dJdq, JW, ddqNull, ddx, ddq, &resErr)) {
+      ROS_ERROR("Failed to solve projection equation!");
+      return ExitCode::InternalError;
+    }
+    if (resErr > LIN_SOLVE_RESIDUAL_TOL) { // check that the solver found a feasible solution
+      ROS_ERROR("Task is infeasible!  resErr: %e > tol: %e", resErr, LIN_SOLVE_RESIDUAL_TOL);
+      return ExitCode::InfeasibleTask;
+    }
+
+    // Check to see if the solution satisfies the joint limits
+    if (checkAccBnd(*ddq)) { // Done! solution is feasible and task scale is at maximum value
+      return ExitCode::Success;
+    }  //  else joint acceleration is infeasible: saturate joint and then try again
+
+    // Compute the task scaling factor
+    double tmpScale;
+    int jntIdx;
+    ExitCode taskScaleExit = computeTaskScalingFactor(J, JW, ddx, *ddq, jointIsFree, &tmpScale, &jntIdx, &resErr);
+    if (resErr > LIN_SOLVE_RESIDUAL_TOL) { // check that the solver found a feasible solution
+      ROS_ERROR("Failed to compute task scale!  resErr: %e > tol: %e", resErr, LIN_SOLVE_RESIDUAL_TOL);
+      return ExitCode::InfeasibleTask;
+    }
+    if (taskScaleExit != ExitCode::Success) {
+      ROS_ERROR("Failed to compute task scale!");
+      return taskScaleExit;
+    }
+    if (tmpScale < MINIMUM_FINITE_SCALE_FACTOR) { // check that the solver found a feasible solution
+      ROS_ERROR("Task is infeasible! scaling --> zero");
+      return ExitCode::InfeasibleTask;
+    }
+
+    if (tmpScale > 1.0) {
+      ROS_ERROR("Task scale is %f, which is more than 1.0", tmpScale);
+      return ExitCode::InternalError;
+    }
+
+    // If the task scale exceeds previous, then cache the results as "best so far"
+    // Also if the current best so far solution violates the limits, update bestTakeScale
+    Eigen::VectorXd ddxScaledTmp = (ddx.array() * bestTaskScale).matrix();
+    Eigen::VectorXd ddqTmp;
+    if (!solveProjectionEquation(J, dJdq, JW, ddqNull, ddxScaledTmp, &ddqTmp, &resErr)) {
+      ROS_ERROR("Failed to solve projection equation!");
+      return ExitCode::InternalError;
+    }
+    if (resErr > LIN_SOLVE_RESIDUAL_TOL) { // check that the solver found a feasible solution
+      ROS_ERROR("Task is infeasible!  resErr: %e > tol: %e", resErr, LIN_SOLVE_RESIDUAL_TOL);
+      return ExitCode::InfeasibleTask;
+    }
+    if (tmpScale > bestTaskScale || !checkAccBnd(ddqTmp)) {
+      bestTaskScale = tmpScale;
+      bestW = W;
+      bestDdqNull = ddqNull;
+    }
+
+    // Saturate the most critical joint
+    W(jntIdx, jntIdx) = 0.0;
+    jointIsFree[jntIdx] = false;
+    if ((*ddq)(jntIdx) > ddqUpp_(jntIdx)) {
+      ddqNull(jntIdx) = ddqUpp_(jntIdx);
+    } else if ((*ddq)(jntIdx) < ddqLow_(jntIdx)) {
+      ddqNull(jntIdx) = ddqLow_(jntIdx);
+    } else {
+      ROS_ERROR("Internal error in computing task scale!  ddq(%d) = %f", jntIdx, (*ddq)(jntIdx));
+      return ExitCode::InternalError;
+    }
+
+    // Update the linear solver
+    JW = J*W;
+    linSolver_ = SnsLinearSolver(JW);
+    if(linSolver_.info() != Eigen::ComputationInfo::Success) {
+      ROS_ERROR("Solver failed to decompose the combined sparse matrix!");
+      return ExitCode::InternalError;
+    }
+
+    // Test the rank:
+    if (linSolver_.rank() < nTask) { // no more degrees of freedom: scale the task
+      (*taskScale) = bestTaskScale;
+      W = bestW;
+      ddqNull = bestDdqNull;
+
+      // Update the linear solver
+      JW = J*W;
+      linSolver_ = SnsLinearSolver(JW);
+      if(linSolver_.info() != Eigen::ComputationInfo::Success) {
+        ROS_ERROR("Solver failed to decompose the combined sparse matrix!");
+        return ExitCode::InternalError;
+      }
+
+      // Compute the joint acceleration given current saturation set:
+      Eigen::VectorXd ddxScaled = (ddx.array() * (*taskScale)).matrix();
+      if (!solveProjectionEquation(J, dJdq, JW, ddqNull, ddxScaled, ddq, &resErr)) {
+        ROS_ERROR("Failed to solve projection equation!");
+        return ExitCode::InternalError;
+      }
+      if (resErr > LIN_SOLVE_RESIDUAL_TOL) { // check that the solver found a feasible solution
+        ROS_ERROR("Task is infeasible!  resErr: %e > tol: %e", resErr, LIN_SOLVE_RESIDUAL_TOL);
+        return ExitCode::InfeasibleTask;
+      }
+
+      return ExitCode::Success;  // DONE
+
+    } // end rank test
+
+  }  // end main solver loop
+
+  ROS_ERROR("Internal Error: reached maximum iteration in solver main loop!");
+  return ExitCode::InternalError;
+}
+
+/*************************************************************************************************
+ *                               Protected Methods                                               *
+ *************************************************************************************************/
+
+bool SnsAccIkBase::checkAccBnd(const Eigen::VectorXd& ddq)
+{
+  if (ddq.size() != nJnt_) {
+    ROS_ERROR("Bad Input:  dq.size(%d) == nJnt(%d) is required!", int(ddq.size()), nJnt_);
+    return false;
+  }
+  for (int i = 0; i < nJnt_; i++) {
+    if (ddq(i) < ddqLow_(i) - ACCELERATION_BOUND_TOLERANCE) { return false; }
+    if (ddq(i) > ddqUpp_(i) + ACCELERATION_BOUND_TOLERANCE) { return false; }
+  }
+  return true;
+}
+
+/*************************************************************************************************/
+
+bool SnsAccIkBase::solveProjectionEquation(const Eigen::MatrixXd& J, const Eigen::VectorXd& dJdq,
+                                           const Eigen::MatrixXd& JW, const Eigen::VectorXd& ddqNull,
+                                           const Eigen::VectorXd& ddx, Eigen::VectorXd* ddq, double* resErr)
+{
+  // Input validation:
+  if (J.cols() != JW.cols()) { ROS_ERROR("Bad Input!  J.cols() != JW.cols()"); return false; }
+  if (J.rows() != JW.rows()) { ROS_ERROR("Bad Input!  J.rows() != JW.rows()"); return false; }
+  if (ddx.size() != J.rows()) { ROS_ERROR("Bad Input!  ddx.size() != J.rows()"); return false; }
+  if (dJdq.size() != ddx.size()) { ROS_ERROR("Bad Input!  ddx.size() != J.rows()"); return false; }
+  if (J.cols() != ddqNull.rows()) { ROS_ERROR("Bad Input!  J.cols() != ddqNull.rows()"); return false; }
+  if (!ddq) { ROS_ERROR("Bad Input!  ddq is nullptr!"); return false; }
+  if (!resErr) { ROS_ERROR("Bad Input!  resErr is nullptr!"); return false; }
+
+  // Solve the linear system
+  Eigen::MatrixXd B = ddx - dJdq - J*ddqNull;
+  Eigen::MatrixXd X = linSolver_.solve(B);
+  if(linSolver_.info() != Eigen::ComputationInfo::Success) {
+    ROS_ERROR("Failed to solve projection equations!");
+    return false;
+  }
+
+  // Solve for ddq
+  *ddq = X + ddqNull;
+  *resErr = (JW*X - B).squaredNorm();
+  return true;
+}
+
+/*************************************************************************************************/
+
+SnsAccIkBase::ExitCode SnsAccIkBase::computeTaskScalingFactor(const Eigen::MatrixXd& J,
+                                            const Eigen::MatrixXd& JW, const Eigen::VectorXd& ddx,
+                                            const Eigen::VectorXd& ddq, const std::vector<bool>& jntIsFree,
+                                            double* taskScale, int* jntIdx, double* resErr)
+{
+  if (J.cols() != JW.cols()) { ROS_ERROR("Bad Input!  J.cols() != JW.cols()"); return ExitCode::BadUserInput; }
+  if (J.rows() != JW.rows()) { ROS_ERROR("Bad Input!  J.rows() != JW.rows()"); return ExitCode::BadUserInput; }
+  if (ddx.size() != J.rows()) { ROS_ERROR("Bad Input!  ddx.size() != J.rows()"); return ExitCode::BadUserInput; }
+  if (ddq.size() != J.cols()) { ROS_ERROR("Bad Input!  ddq.size() != J.cols()"); return ExitCode::BadUserInput; }
+  if (!taskScale) { ROS_ERROR("taskScale is nullptr!"); return ExitCode::BadUserInput; }
+  if (!jntIdx) { ROS_ERROR("jntIdx is nullptr!"); return ExitCode::BadUserInput; }
+  if (!resErr) { ROS_ERROR("resErr is nullptr!"); return ExitCode::BadUserInput; }
+
+  // Compute "a" and "b" from the paper.   (J*W*a = ddx)
+  Eigen::VectorXd a = linSolver_.solve(ddx);
+  if(linSolver_.info() != Eigen::ComputationInfo::Success) {
+    ROS_ERROR("Failed to solve projection equations!");
+    return ExitCode::InternalError;
+  }
+  *resErr = (JW*a - ddx).squaredNorm();
+  Eigen::ArrayXd b = (ddq - a).array();
+
+  // Compute the task scale associated with each joint
+  Eigen::ArrayXd jntScaleFactorArr(nJnt_);
+  Eigen::ArrayXd lowMargin = (ddqLow_ - b);
+  Eigen::ArrayXd uppMargin = (ddqUpp_ - b);
+  for (int i = 0; i < nJnt_; i++) {
+    if (jntIsFree[i]) {
+      jntScaleFactorArr(i) = SnsAccIkBase::findScaleFactor(lowMargin(i), uppMargin(i), a(i));
+      // if scale factor is 1 but joint limit gets violated, set the scale factor
+      // to a small number so that the corresponding joint will get saturated
+      if (jntScaleFactorArr(i) == 1 &&
+          (ddq(i) < ddqLow_(i) - ACCELERATION_BOUND_TOLERANCE ||
+           ddq(i) > ddqUpp_(i) + ACCELERATION_BOUND_TOLERANCE)) {
+        jntScaleFactorArr(i) = ACCELERATION_BOUND_TOLERANCE;
+      }
+    } else {  // joint is constrained
+      jntScaleFactorArr(i) = POS_INF;
+    }
+  }
+
+  // Compute the most critical scale factor and corresponding joint index
+  *jntIdx = 0;  // index of the most critical joint
+  *taskScale = jntScaleFactorArr(0);  // minimum value of jntScaleFactorArr()
+  for (int i = 1; i < nJnt_; i++) {
+    if (jntScaleFactorArr(i) < *taskScale) {
+      *jntIdx = i;
+      *taskScale = jntScaleFactorArr(i);
+    }
+  }
+
+  return ExitCode::Success;
+}
+
+/*************************************************************************************************/
+
+double SnsAccIkBase::findScaleFactor(double low, double upp, double a)
+{
+  if (std::abs(a) > MAXIMUM_FINITE_SCALE_FACTOR) {
+    return 0.0;
+  }
+  if (a < 0.0 && low < 0.0) {
+    if (a < low) {
+      return low / std::min(a, -MINIMUM_FINITE_SCALE_FACTOR);
+    } else {
+      return 1.0;  // feasible without scaling!
+    }
+  } else if (a > 0.0 && upp > 0.0) {
+    if (upp < a) {
+      return upp / std::max(a, MINIMUM_FINITE_SCALE_FACTOR);
+    } else {
+      return 1.0;  // feasible without scaling!
+    }
+  } else {
+    return 0.0;  // infeasible
+  }
+}
+
+/*************************************************************************************************/
+
+}  // namespace sns_ik

--- a/sns_ik_lib/test/sns_acc_ik_base_test.cpp
+++ b/sns_ik_lib/test/sns_acc_ik_base_test.cpp
@@ -2,6 +2,7 @@
  *
  *  @brief Unit Test: sns_acc_ik_base solver
  *  @author Matthew Kelly
+ *  @author Andy Park
  *
  *    Copyright 2018 Rethink Robotics
  *
@@ -24,35 +25,13 @@
 
 #include <sns_ik/sns_acc_ik_base.hpp>
 #include "rng_utilities.hpp"
-
-/*************************************************************************************************/
-
-void checkEqualVector(const Eigen::VectorXd& A, const Eigen::VectorXd& B, double tol)
-{
-  ASSERT_EQ(A.size(), B.size());
-  int n = A.size();
-  for (int i = 0; i < n; i++) {
-    ASSERT_NEAR(A(i), B(i), tol);
-  }
-}
-
-/*************************************************************************************************/
-
-void checkVectorLimits(const Eigen::VectorXd& low, const Eigen::VectorXd& val, const Eigen::VectorXd& upp, double tol)
-{
-  ASSERT_EQ(low.size(), val.size());
-  ASSERT_EQ(upp.size(), val.size());
-  int n = val.size();
-  for (int i = 0; i < n; i++) {
-    ASSERT_LE(val(i), upp(i) + tol);
-    ASSERT_GE(val(i), low(i) - tol);
-  }
-}
+#include "test_utilities.hpp"
 
 /*************************************************************************************************/
 
 /*
- * This test is for the solveAccIkBasic()
+ * This test is for the SnsAccIkBase::solve() without any joint limits.
+ * This checks whether the solution obtained from SNS IK without limits is valid.
  */
 TEST(sns_acc_ik_base, basic_no_limits)
 {
@@ -62,8 +41,8 @@ TEST(sns_acc_ik_base, basic_no_limits)
   for (int iTest = 0; iTest < nTest; iTest++) {
 
     // generate a test problem
-    int nTask = sns_ik::rng_util::getRngInt(0, 1, 6);
-    int nJoint = sns_ik::rng_util::getRngInt(0, nTask, nTask + 4);
+    int nJoint = sns_ik::rng_util::getRngInt(0, 1, 8);
+    int nTask = sns_ik::rng_util::getRngInt(0, 1, nJoint);
     Eigen::MatrixXd J = sns_ik::rng_util::getRngMatrixXd(0, nTask, nJoint, -1.0, 1.0);
     Eigen::MatrixXd dJdq = sns_ik::rng_util::getRngVectorXd(0, nTask, -1.0, 1.0);
     Eigen::VectorXd ddx = sns_ik::rng_util::getRngVectorXd(0, nTask, -1.0, 1.0);
@@ -80,14 +59,19 @@ TEST(sns_acc_ik_base, basic_no_limits)
     // check requirements
     ASSERT_LE(taskScale, 1.0 + tol);
     ASSERT_GT(taskScale, 0.0);
-    checkEqualVector(taskScale * ddx, J * ddq + dJdq, tol);
+    sns_ik::test_util::checkEqualVector(taskScale * ddx, J * ddq + dJdq, tol);
   }
 }
 
 /*************************************************************************************************/
 
 /*
- * This test is for the solveAccIkBasic()
+ * This test is for the SnsAccIkBase::solve() with joint limits.
+ * This checks if the solution obtained from SNS IK with limits is valid.
+ * Test data including task scale factor is randomly generated and they
+ * will be compared against the solution from the solver. A solution is
+ * considered valid if it is within the limits while meeting the goal
+ * task acceleration with the computed task scale factor.
  */
 TEST(sns_acc_ik_base, basic_with_limits)
 {
@@ -129,8 +113,8 @@ TEST(sns_acc_ik_base, basic_with_limits)
       // check requirements
       ASSERT_LE(taskScale, 1.0 + tol);
       if (taskScale < taskScaleMin - tol) nSubOpt++;
-      checkEqualVector(taskScale * ddx, J * ddq + dJdq, tol);
-      checkVectorLimits(ddqLow, ddq, ddqUpp, tol);
+      sns_ik::test_util::checkEqualVector(taskScale * ddx, J * ddq + dJdq, tol);
+      sns_ik::test_util::checkVectorLimits(ddqLow, ddq, ddqUpp, tol);
     } else {
       nFail++;
       EXPECT_TRUE(false) << "Solver failed  --  infeasible task?";

--- a/sns_ik_lib/test/sns_acc_ik_base_test.cpp
+++ b/sns_ik_lib/test/sns_acc_ik_base_test.cpp
@@ -1,6 +1,6 @@
-/**  @file sns_vel_ik_base_test.cpp
+/**  @file sns_acc_ik_base_test.cpp
  *
- *  @brief Unit Test: sns_vel_ik_base solver
+ *  @brief Unit Test: sns_acc_ik_base solver
  *  @author Matthew Kelly
  *
  *    Copyright 2018 Rethink Robotics
@@ -22,7 +22,7 @@
 #include <Eigen/Dense>
 #include <ros/console.h>
 
-#include <sns_ik/sns_vel_ik_base.hpp>
+#include <sns_ik/sns_acc_ik_base.hpp>
 #include "rng_utilities.hpp"
 
 /*************************************************************************************************/
@@ -52,9 +52,9 @@ void checkVectorLimits(const Eigen::VectorXd& low, const Eigen::VectorXd& val, c
 /*************************************************************************************************/
 
 /*
- * This test is for the solveVelIkBasic()
+ * This test is for the solveAccIkBasic()
  */
-TEST(sns_vel_ik_base, basic_no_limits)
+TEST(sns_acc_ik_base, basic_no_limits)
 {
   sns_ik::rng_util::setRngSeed(75716, 11487);  // set the initial seed for the random number generators
   int nTest = 100;
@@ -65,32 +65,33 @@ TEST(sns_vel_ik_base, basic_no_limits)
     int nTask = sns_ik::rng_util::getRngInt(0, 1, 6);
     int nJoint = sns_ik::rng_util::getRngInt(0, nTask, nTask + 4);
     Eigen::MatrixXd J = sns_ik::rng_util::getRngMatrixXd(0, nTask, nJoint, -1.0, 1.0);
-    Eigen::VectorXd dx = sns_ik::rng_util::getRngVectorXd(0, nTask, -1.0, 1.0);
+    Eigen::MatrixXd dJdq = sns_ik::rng_util::getRngVectorXd(0, nTask, -1.0, 1.0);
+    Eigen::VectorXd ddx = sns_ik::rng_util::getRngVectorXd(0, nTask, -1.0, 1.0);
     Eigen::VectorXd tolVec = tol * Eigen::VectorXd::Ones(nJoint);
-    Eigen::VectorXd dq;
+    Eigen::VectorXd ddq;
     double taskScale;
 
     // solve
-    sns_ik::SnsVelIkBase::uPtr ikSolver = sns_ik::SnsVelIkBase::create(nJoint);
+    sns_ik::SnsAccIkBase::uPtr ikSolver = sns_ik::SnsAccIkBase::create(nJoint);
     ASSERT_TRUE(ikSolver.get() != nullptr);
-    sns_ik::SnsVelIkBase::ExitCode exitCode = ikSolver->solve(J, dx, &dq, &taskScale);
-    ASSERT_TRUE(exitCode == sns_ik::SnsVelIkBase::ExitCode::Success);
+    sns_ik::SnsAccIkBase::ExitCode exitCode = ikSolver->solve(J, dJdq, ddx, &ddq, &taskScale);
+    ASSERT_TRUE(exitCode == sns_ik::SnsAccIkBase::ExitCode::Success);
 
     // check requirements
     ASSERT_LE(taskScale, 1.0 + tol);
     ASSERT_GT(taskScale, 0.0);
-    checkEqualVector(taskScale * dx, J * dq, tol);
+    checkEqualVector(taskScale * ddx, J * ddq + dJdq, tol);
   }
 }
 
 /*************************************************************************************************/
 
 /*
- * This test is for the solveVelIkBasic()
+ * This test is for the solveAccIkBasic()
  */
-TEST(sns_vel_ik_base, basic_with_limits)
+TEST(sns_acc_ik_base, basic_with_limits)
 {
-  sns_ik::rng_util::setRngSeed(65444, 24635);  // set the initial seed for the random number generators
+  sns_ik::rng_util::setRngSeed(65444, 48535);  // set the initial seed for the random number generators
   int nTest = 10000;
   double tol = 1e-10;
   int nPass = 0;
@@ -99,36 +100,37 @@ TEST(sns_vel_ik_base, basic_with_limits)
   double meanSolveTime = 0.0;
   for (int iTest = 0; iTest < nTest; iTest++) {
     // generate a test problem
-    int nTask = sns_ik::rng_util::getRngInt(0, 1, 6);
-    int nJoint = sns_ik::rng_util::getRngInt(0, nTask, nTask + 4);
-    Eigen::MatrixXd J = sns_ik::rng_util::getRngMatrixXd(0, nTask, nJoint, -2.0, 2.0);
-    Eigen::ArrayXd dqLow = sns_ik::rng_util::getRngVectorXd(0, nJoint, -5.0, -0.5);
-    Eigen::ArrayXd dqUpp = sns_ik::rng_util::getRngVectorXd(0, nJoint, 0.5, 5.0);
-    Eigen::VectorXd dqTest = sns_ik::rng_util::getRngArrBndXd(0, dqLow, dqUpp).matrix();
+    int nJoint = sns_ik::rng_util::getRngInt(0, 1, 8);
+    int nTask = sns_ik::rng_util::getRngInt(0, 1, nJoint);
+    Eigen::MatrixXd J = sns_ik::rng_util::getRngMatrixXd(0, nTask, nJoint, -3.0, 3.0);
+    Eigen::ArrayXd ddqLow = sns_ik::rng_util::getRngVectorXd(0, nJoint, -3.0, -1.0);
+    Eigen::ArrayXd ddqUpp = sns_ik::rng_util::getRngVectorXd(0, nJoint, 1.0, 3.0);
+    Eigen::VectorXd ddqTest = sns_ik::rng_util::getRngArrBndXd(0, ddqLow, ddqUpp).matrix();
+    Eigen::VectorXd dJdq = sns_ik::rng_util::getRngVectorXd(0, nTask, -1.0, 1.0);
 
     // create a task that is feasible with scaling
-    Eigen::VectorXd dxFeas = J*dqTest; // this task velocity is feasible by definition
+    Eigen::VectorXd ddxFeas = J*ddqTest + dJdq; // this task acceleration is feasible by definition
     double taskScaleMin = sns_ik::rng_util::getRngDouble(0, 0.2, 1.2);
     taskScaleMin = std::min(1.0, taskScaleMin);  // clamp max value to 1.0
-    Eigen::VectorXd dx = dxFeas / taskScaleMin;
+    Eigen::VectorXd ddx = ddxFeas / taskScaleMin;
 
     // solve
-    Eigen::VectorXd dq;
+    Eigen::VectorXd ddq;
     double taskScale;
-    sns_ik::SnsVelIkBase::uPtr ikSolver = sns_ik::SnsVelIkBase::create(dqLow, dqUpp);
+    sns_ik::SnsAccIkBase::uPtr ikSolver = sns_ik::SnsAccIkBase::create(ddqLow, ddqUpp);
     ASSERT_TRUE(ikSolver.get() != nullptr);
     ros::Time startTime = ros::Time::now();
-    sns_ik::SnsVelIkBase::ExitCode exitCode = ikSolver->solve(J, dx, &dq, &taskScale);
+    sns_ik::SnsAccIkBase::ExitCode exitCode = ikSolver->solve(J, dJdq, ddx, &ddq, &taskScale);
     double solveTime = (ros::Time::now() - startTime).toSec();
     meanSolveTime += solveTime;
 
-    if (exitCode == sns_ik::SnsVelIkBase::ExitCode::Success) {
+    if (exitCode == sns_ik::SnsAccIkBase::ExitCode::Success) {
       nPass++;
       // check requirements
       ASSERT_LE(taskScale, 1.0 + tol);
       if (taskScale < taskScaleMin - tol) nSubOpt++;
-      checkEqualVector(taskScale * dx, J * dq, tol);
-      checkVectorLimits(dqLow, dq, dqUpp, tol);
+      checkEqualVector(taskScale * ddx, J * ddq + dJdq, tol);
+      checkVectorLimits(ddqLow, ddq, ddqUpp, tol);
     } else {
       nFail++;
       EXPECT_TRUE(false) << "Solver failed  --  infeasible task?";

--- a/sns_ik_lib/test/test_utilities.cpp
+++ b/sns_ik_lib/test/test_utilities.cpp
@@ -1,0 +1,54 @@
+/*
+ *    Copyright 2018 Rethink Robotics
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+
+#include <gtest/gtest.h>
+
+#include <Eigen/Dense>
+#include <ros/console.h>
+
+#include "test_utilities.hpp"
+
+namespace sns_ik {
+namespace test_util {
+
+/*************************************************************************************************/
+
+void checkEqualVector(const Eigen::VectorXd& A, const Eigen::VectorXd& B, double tol)
+{
+  ASSERT_EQ(A.size(), B.size());
+  int n = A.size();
+  for (int i = 0; i < n; i++) {
+    ASSERT_NEAR(A(i), B(i), tol);
+  }
+}
+
+/*************************************************************************************************/
+
+void checkVectorLimits(const Eigen::VectorXd& low, const Eigen::VectorXd& val, const Eigen::VectorXd& upp, double tol)
+{
+  ASSERT_EQ(low.size(), val.size());
+  ASSERT_EQ(upp.size(), val.size());
+  int n = val.size();
+  for (int i = 0; i < n; i++) {
+    ASSERT_LE(val(i), upp(i) + tol);
+    ASSERT_GE(val(i), low(i) - tol);
+  }
+}
+
+/*************************************************************************************************/
+
+} // namespace test_util
+} // namespace sns_ik

--- a/sns_ik_lib/test/test_utilities.hpp
+++ b/sns_ik_lib/test/test_utilities.hpp
@@ -1,0 +1,49 @@
+/** @file test_utilities.hpp
+ *
+ * @brief a collection of functions for testing Eigen type vector data
+ *
+ * @author Matthew Kelly
+ * @author Andy Park
+ *
+ * This file provides a set of functions that are used to generate repeatable pseudo-random
+ * data for unit tests. All functions provide the caller with direct control over the seed that
+ * is used by the random number generator. Passing a seed of zero is used to indicate that the
+ * seed should not be reset, instead letting the random generator progress to the next value in
+ * the sequence. This is useful for generating numbers in a loop, such as for a matrix.
+ *
+ *    Copyright 2018 Rethink Robotics
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#ifndef SNS_IK_LIB_TEST_UTILITIES_H
+#define SNS_IK_LIB_TEST_UTILITIES_H
+
+#include <Eigen/Dense>
+
+namespace sns_ik {
+namespace test_util {
+
+/**
+ * Check if the elements in vector A and B are equal
+ */
+void checkEqualVector(const Eigen::VectorXd& A, const Eigen::VectorXd& B, double tol);
+
+/**
+ * Check if the elements in a vector are within lower and upper limits
+ */
+void checkVectorLimits(const Eigen::VectorXd& low, const Eigen::VectorXd& val, const Eigen::VectorXd& upp, double tol);
+
+}  // namespace test_util
+}  // namespace sns_ik
+
+#endif //SNS_IK_LIB_TEST_UTILITIES_H


### PR DESCRIPTION
This commit adds acceleration-based sns ik base solver including
unit tests. It was written on top of Matt's initial code ported from 
base velocity sns ik solver. 