### PR TITLE
Adds a new functionality to enable a secondary goal

### DIFF
--- a/sns_ik_lib/include/sns_ik/sns_ik_base.hpp
+++ b/sns_ik_lib/include/sns_ik/sns_ik_base.hpp
@@ -26,6 +26,7 @@
 #include <memory>
 
 #include "sns_linear_solver.hpp"
+#include "sns_ik_math_utils.hpp"
 
 namespace sns_ik {
 

--- a/sns_ik_lib/src/sns_acc_ik_base.cpp
+++ b/sns_ik_lib/src/sns_acc_ik_base.cpp
@@ -309,7 +309,7 @@ SnsIkBase::ExitCode SnsAccIkBase::solve(const Eigen::MatrixXd& J, const Eigen::V
     ROS_WARN("Secondary goal is infeasible! scaling --> zero");
   }
 
-  // compute the additional joint velocity due to the secondary goal
+  // compute the additional joint acceleration due to the secondary goal
   Eigen::VectorXd ddqDelta = ((Pcs*ddqCS).array() * (*taskScaleCS)).matrix();
 
   // compute the final solution

--- a/sns_ik_lib/src/sns_acc_ik_base.cpp
+++ b/sns_ik_lib/src/sns_acc_ik_base.cpp
@@ -63,7 +63,7 @@ SnsAccIkBase::uPtr SnsAccIkBase::create(const Eigen::ArrayXd& ddqLow, const Eige
 /*************************************************************************************************/
 
 SnsIkBase::ExitCode SnsAccIkBase::solve(const Eigen::MatrixXd& J, const Eigen::VectorXd& dJdq,
-                                           const Eigen::VectorXd& ddx, Eigen::VectorXd* ddq, double* taskScale)
+                                        const Eigen::VectorXd& ddx, Eigen::VectorXd* ddq, double* taskScale)
 {
   // Input validation
   if (!ddq) { ROS_ERROR("ddq is nullptr!"); return ExitCode::BadUserInput; }
@@ -214,6 +214,108 @@ SnsIkBase::ExitCode SnsAccIkBase::solve(const Eigen::MatrixXd& J, const Eigen::V
 
   ROS_ERROR("Internal Error: reached maximum iteration in solver main loop!");
   return ExitCode::InternalError;
+}
+
+/*************************************************************************************************/
+
+SnsIkBase::ExitCode SnsAccIkBase::solve(const Eigen::MatrixXd& J, const Eigen::VectorXd& dJdq,
+                                        const Eigen::VectorXd& ddx, const Eigen::VectorXd& ddqCS,
+                                        Eigen::VectorXd* ddq, double* taskScale, double* taskScaleCS)
+{
+  // Input validation
+  if (size_t(ddqCS.rows()) != getNrOfJoints()) {
+    ROS_ERROR("Bad Input: ddqCS.rows() == nJnt is required!");
+    return ExitCode::BadUserInput;
+  }
+
+  //--- get the solution for the primary goal
+  Eigen::VectorXd ddq1;
+  SnsIkBase::ExitCode exitCode = solve(J, dJdq, ddx, &ddq1, taskScale);
+  if (exitCode != ExitCode::Success) {
+    ROS_ERROR("Primary goal did not find a solution! Terminating..");
+    return exitCode;
+  }
+
+  //--- find the solution for the secondary goal
+
+  *taskScaleCS = 1.0;  // task scale (assume feasible solution until proven otherwise)
+  Eigen::MatrixXd I = Eigen::MatrixXd::Identity(getNrOfJoints(), getNrOfJoints());
+
+  // Keep track of which joints are saturated:
+  std::vector<bool> jointIsFree(getNrOfJoints(), true);
+
+  /*
+   * W is a diagonal selection matrix which indicates free joints.
+   * The entry of 1 indicates the corresponding joint is free for the task,
+   * and 0 indicates the corresponding joint is saturated.
+   */
+  Eigen::MatrixXd W = I;  // null-space selection matrix
+  for (size_t jntIdx = 0; jntIdx < getNrOfJoints(); jntIdx++) {
+    if (ddq1(jntIdx) > (getUpperBounds())(jntIdx) + BOUND_TOLERANCE ||
+        ddq1(jntIdx) < (getLowerBounds())(jntIdx) - BOUND_TOLERANCE) {
+          W(jntIdx, jntIdx) = 0.0;
+          jointIsFree[jntIdx] = false;
+    }
+  }
+
+  // Compute nullspace projection matrix
+  Eigen::MatrixXd Jinv, Pinv;
+  if(!pinv(J, &Jinv, LIN_SOLVE_RESIDUAL_TOL)) {
+    ROS_ERROR("Pseudo-inverse of J cannot be computed!");
+    return ExitCode::InternalError;
+  }
+
+  Eigen::MatrixXd P1 = I - Jinv*J; // for primary task
+  if(!pinv((I - W)*P1, &Pinv, LIN_SOLVE_RESIDUAL_TOL)){
+    // if (I-W) is a zero matrix, inverse is the same
+    Pinv = (I - W)*P1;
+  }
+  Eigen::MatrixXd Pcs = (I - Pinv)*P1; // for both primary and joint saturation tasks
+
+  // Compute "a" and "b" from the paper.   (J*W*a = dx)
+  Eigen::VectorXd a = Pcs * ddqCS;
+  Eigen::ArrayXd b = ddq1.array();
+
+  // Compute the task scale associated with each joint
+  Eigen::ArrayXd jntScaleFactorArr(getNrOfJoints());
+  Eigen::ArrayXd lowMargin = (getLowerBounds() - b);
+  Eigen::ArrayXd uppMargin = (getUpperBounds() - b);
+  for (size_t i = 0; i < getNrOfJoints(); i++) {
+    if (jointIsFree[i]) {
+      jntScaleFactorArr(i) = findScaleFactor(lowMargin(i), uppMargin(i), a(i));
+    } else {  // joint is constrained
+      jntScaleFactorArr(i) = POS_INF;
+    }
+  }
+
+  // Compute the most critical scale factor and corresponding joint index
+  *taskScaleCS = jntScaleFactorArr(0);  // minimum value of jntScaleFactorArr()
+  for (size_t i = 1; i < getNrOfJoints(); i++) {
+    if (jntScaleFactorArr(i) < *taskScaleCS) {
+      *taskScaleCS = jntScaleFactorArr(i);
+    }
+  }
+
+  if (*taskScaleCS == POS_INF) {
+    // if all joints are saturated, secondary goal becomes infeasible!
+    *taskScaleCS = 0;
+    ROS_WARN("All joints are saturated! Secondary goal is infeasible!");
+  }
+  else if (*taskScaleCS > 1.0) {
+    ROS_ERROR("Task scale is %f, which is more than 1.0", *taskScaleCS);
+    return ExitCode::InternalError;
+  }
+  else if (*taskScaleCS < MINIMUM_FINITE_SCALE_FACTOR) {
+    ROS_WARN("Secondary goal is infeasible! scaling --> zero");
+  }
+
+  // compute the additional joint velocity due to the secondary goal
+  Eigen::VectorXd ddqDelta = ((Pcs*ddqCS).array() * (*taskScaleCS)).matrix();
+
+  // compute the final solution
+  *ddq = ddq1 + ddqDelta;
+
+  return ExitCode::Success;
 }
 
 /*************************************************************************************************

--- a/sns_ik_lib/src/sns_acc_ik_base.cpp
+++ b/sns_ik_lib/src/sns_acc_ik_base.cpp
@@ -278,6 +278,9 @@ SnsIkBase::ExitCode SnsAccIkBase::solve(const Eigen::MatrixXd& J, const Eigen::V
 
   // Compute the task scale associated with each joint
   Eigen::ArrayXd jntScaleFactorArr(getNrOfJoints());
+  // here lower and upper margins are defined as the budget for the desired task (xdd) only
+  // qdd needs to accomplish both task-independent term (b) as well as desired task (xdd)
+  // within the upper and lower bounds.
   Eigen::ArrayXd lowMargin = (getLowerBounds() - b);
   Eigen::ArrayXd uppMargin = (getUpperBounds() - b);
   for (size_t i = 0; i < getNrOfJoints(); i++) {

--- a/sns_ik_lib/src/sns_vel_ik_base.cpp
+++ b/sns_ik_lib/src/sns_vel_ik_base.cpp
@@ -263,6 +263,9 @@ SnsIkBase::ExitCode SnsVelIkBase::solve(const Eigen::MatrixXd& J, const Eigen::V
 
   // Compute the task scale associated with each joint
   Eigen::ArrayXd jntScaleFactorArr(getNrOfJoints());
+  // here lower and upper margins are defined as the budget for the desired task (xd) only
+  // qd needs to accomplish both task-independent term (b) as well as desired task (xd)
+  // within the upper and lower bounds.
   Eigen::ArrayXd lowMargin = (getLowerBounds() - b);
   Eigen::ArrayXd uppMargin = (getUpperBounds() - b);
   for (size_t i = 0; i < getNrOfJoints(); i++) {

--- a/sns_ik_lib/test/sns_vel_ik_base_test.cpp
+++ b/sns_ik_lib/test/sns_vel_ik_base_test.cpp
@@ -128,6 +128,75 @@ TEST(sns_vel_ik_base, basic_with_limits)
 
 /*************************************************************************************************/
 
+/*
+ * This test is for the SnsVelIkBase::solve() with a secondary goal (as well as joint limits).
+ * This checks if the solution obtained from SNS IK with limits is valid.
+ * Test data including task scale factor is randomly generated and they
+ * will be compared against the solution from the solver. A solution is
+ * considered valid if it is within the limits while meeting the goal
+ * task velocity with the computed task scale factor.
+ */
+TEST(sns_vel_ik_base, basic_with_secondary_goal)
+{
+  sns_ik::rng_util::setRngSeed(65444, 24635);  // set the initial seed for the random number generators
+  int nTest = 10000;
+  double tol = 1e-10;
+  int nPass = 0;
+  int nFail = 0;
+  int nSubOpt = 0;
+  double meanSolveTime = 0.0;
+  double meanTaskScaleCS = 0.0;
+  for (int iTest = 0; iTest < nTest; iTest++) {
+    // generate a test problem
+    int nTask = sns_ik::rng_util::getRngInt(0, 1, 6);
+    int nJoint = sns_ik::rng_util::getRngInt(0, nTask, nTask + 4);
+    Eigen::MatrixXd J = sns_ik::rng_util::getRngMatrixXd(0, nTask, nJoint, -2.0, 2.0);
+    Eigen::ArrayXd dqLow = sns_ik::rng_util::getRngVectorXd(0, nJoint, -5.0, -0.5);
+    Eigen::ArrayXd dqUpp = sns_ik::rng_util::getRngVectorXd(0, nJoint, 0.5, 5.0);
+    Eigen::VectorXd dqTest = sns_ik::rng_util::getRngArrBndXd(0, dqLow, dqUpp).matrix();
+
+    // create a task that is feasible with scaling
+    Eigen::VectorXd dxFeas = J*dqTest; // this task velocity is feasible by definition
+    double taskScaleMin = sns_ik::rng_util::getRngDouble(0, 0.2, 1.2);
+    taskScaleMin = std::min(1.0, taskScaleMin);  // clamp max value to 1.0
+    Eigen::VectorXd dx = dxFeas / taskScaleMin;
+
+    // generate a configuration space task as secondary goal
+    Eigen::VectorXd dqCS = sns_ik::rng_util::getRngArrBndXd(0, dqLow, dqUpp).matrix();
+
+    // solve
+    Eigen::VectorXd dq;
+    double taskScale, taskScaleCS;
+    sns_ik::SnsVelIkBase::uPtr ikSolver = sns_ik::SnsVelIkBase::create(dqLow, dqUpp);
+    ASSERT_TRUE(ikSolver.get() != nullptr);
+    ros::Time startTime = ros::Time::now();
+    sns_ik::SnsIkBase::ExitCode exitCode = ikSolver->solve(J, dx, dqCS, &dq, &taskScale, &taskScaleCS);
+    double solveTime = (ros::Time::now() - startTime).toSec();
+    meanSolveTime += solveTime;
+    meanTaskScaleCS += taskScaleCS;
+
+    if (exitCode == sns_ik::SnsIkBase::ExitCode::Success) {
+      nPass++;
+      // check requirements
+      ASSERT_LE(taskScale, 1.0 + tol);
+      if (taskScale < taskScaleMin - tol) nSubOpt++;
+      sns_ik::test_util::checkEqualVector(taskScale * dx, J * dq, tol);
+      sns_ik::test_util::checkVectorLimits(dqLow, dq, dqUpp, tol);
+    } else {
+      nFail++;
+      EXPECT_TRUE(false) << "Solver failed  --  infeasible task?";
+    }
+  }
+  meanSolveTime /= static_cast<double>(nPass + nFail);
+  meanTaskScaleCS /= static_cast<double>(nPass);
+
+  ROS_INFO("Pass: %d  --  Fail: %d  --  nSubOpt: %d  --  Mean solve time: %.4f ms -- Mean secondary goal scale : %.4f",
+           nPass, nFail, nSubOpt, meanSolveTime*1000.0, meanTaskScaleCS);
+}
+
+
+/*************************************************************************************************/
+
 // Run all the tests that were declared with TEST()
 int main(int argc, char **argv){
   ros::Time::init();


### PR DESCRIPTION
This commit adds new functionalities to vel/acc IK solvers
so that they can now take a configuration space task as a
secondary goal. A simple application of this feature will
be to have a nullspace bias which will help stabilizing
the nullspace motion as well as getting the solution pose
close to a desired pose. Unit tests are added as well.