### PR TITLE
Added missing include in base sns-ik

### DIFF
--- a/sns_ik_lib/include/sns_ik/sns_ik_base.hpp
+++ b/sns_ik_lib/include/sns_ik/sns_ik_base.hpp
@@ -24,6 +24,7 @@
 
 #include <Eigen/Dense>
 #include <memory>
+#include <vector>
 
 #include "sns_linear_solver.hpp"
 


### PR DESCRIPTION
Without this include, the gcc compiler in `Ubuntu 18.04` errors out on building the package.