### PR TITLE
Fix failing melodic tests

### DIFF
--- a/sns_ik_lib/include/sns_ik/sns_position_ik.hpp
+++ b/sns_ik_lib/include/sns_ik/sns_position_ik.hpp
@@ -32,7 +32,7 @@ namespace sns_ik {
 class SNSVelocityIK;
 class SNSPositionIK {
   public:
-    SNSPositionIK(KDL::Chain chain, std::shared_ptr<SNSVelocityIK> velocity_ik, double eps=1e-5);
+    SNSPositionIK(const KDL::Chain& chain, std::shared_ptr<SNSVelocityIK> velocity_ik, double eps=1e-5);
     ~SNSPositionIK();
 
     int CartToJnt(const KDL::JntArray& joint_seed,

--- a/sns_ik_lib/src/sns_position_ik.cpp
+++ b/sns_ik_lib/src/sns_position_ik.cpp
@@ -25,11 +25,13 @@
 
 namespace sns_ik {
 
-SNSPositionIK::SNSPositionIK(KDL::Chain chain, std::shared_ptr<SNSVelocityIK> velocity_ik, double eps) :
+SNSPositionIK::SNSPositionIK(const KDL::Chain& chain, std::shared_ptr<SNSVelocityIK> velocity_ik, double eps) :
     m_chain(chain),
     m_ikVelSolver(velocity_ik),
-    m_positionFK(chain),
-    m_jacobianSolver(chain),
+    // NOTE: m_positionFK and m_jacobianSolver are only holding a reference to chain
+    // so it's important that m_chain is not destroyed and is initialized before them
+    m_positionFK(m_chain),
+    m_jacobianSolver(m_chain),
     m_linearMaxStepSize(0.2),
     m_angularMaxStepSize(0.2),
     m_maxIterations(150),

--- a/sns_ik_lib/test/sns_ik_pos_test.cpp
+++ b/sns_ik_lib/test/sns_ik_pos_test.cpp
@@ -117,7 +117,7 @@ PosTestResult runPosIkSingleTest(int seed, const KDL::JntArray& qLow, const KDL:
   }
 
   // loop over each solver type
-  KDL::JntArray qSoln;
+  KDL::JntArray qSoln(qTest.rows()); // solution must be the correct size for solve call
   PosTestResult result;
   result.solveTime = ros::Duration(0);
   result.nPass = 0;


### PR DESCRIPTION
Fixes issue with dangling reference and invalid initialization.

The JntArray initialization fix was causing KDL_test_1 to fail because it checked that the ChainIkSolverPos_NR_JL::CartToJnt checks that output JntArray has the correct size.

The SNSPositionIK change (passing in a reference to chain) fixes an issue with a dangling reference - m_positionFK and m_jacobianSolver only hold a reference to the chain they are passed so it's necessary that the copy be kept alive somewhere. When it was passed by value, a temporary copy was made and then destroyed.

This fixes the tests for me locally in Ubuntu 18.04 and melodic.